### PR TITLE
Implement RecursiveAir for Air

### DIFF
--- a/recursion/Cargo.toml
+++ b/recursion/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 # Plonky3 dependencies
+p3-air.workspace = true
 p3-commit.workspace = true
 p3-field.workspace = true
 p3-uni-stark.workspace = true


### PR DESCRIPTION
Small PR to implement `RecursiveAir` for `Air`. It can make #82, #79  and future PRs slightly easier.