### PR TITLE
renaming: `transparent` -> `preprocessed` columns

### DIFF
--- a/circuit-prover/src/air/const_air.rs
+++ b/circuit-prover/src/air/const_air.rs
@@ -10,13 +10,13 @@ use super::utils::pad_to_power_of_two;
 
 /// ConstAir: vector-valued constant binding with generic extension degree D.
 ///
-/// This chip exposes transparent constants that don't need to be committed during proving.
+/// This chip exposes preprocessed constants that don't need to be committed during proving.
 /// It serves as the source of truth for constant values in the system, with each row
 /// representing a (value, index) pair where the index corresponds to a WitnessId.
 ///
 /// Layout per row: [value[0..D-1], index] → width = D + 1
 /// - value[0..D-1]: Extension field value represented as D base field coefficients
-/// - index: Transparent WitnessId that this constant binds to
+/// - index: Preprocessed WitnessId that this constant binds to
 #[derive(Debug, Clone)]
 pub struct ConstAir<F, const D: usize = 1> {
     pub height: usize,

--- a/circuit-prover/src/air/witness_air.rs
+++ b/circuit-prover/src/air/witness_air.rs
@@ -9,7 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 
 use super::utils::pad_witness_to_power_of_two;
 
-/// WitnessAir: enforces transparent index column monotonicity.
+/// WitnessAir: enforces preprocessed index column monotonicity.
 /// Layout per row: [value[0..D-1], index]
 /// Constraints:
 ///  - index[0] = 0

--- a/circuit/src/tables.rs
+++ b/circuit/src/tables.rs
@@ -99,10 +99,10 @@ pub struct Traces<F> {
     pub fake_merkle_trace: FakeMerkleTrace<F>,
 }
 
-/// Central witness table with transparent index column
+/// Central witness table with preprocessed index column
 #[derive(Debug, Clone)]
 pub struct WitnessTrace<F> {
-    /// Transparent index column (0, 1, 2, ...)
+    /// Preprocessed index column (0, 1, 2, ...)
     pub index: Vec<u32>,
     /// Witness values
     pub values: Vec<F>,
@@ -111,7 +111,7 @@ pub struct WitnessTrace<F> {
 /// Constant table
 #[derive(Debug, Clone)]
 pub struct ConstTrace<F> {
-    /// Transparent index column (equals the WitnessId this row binds)
+    /// Preprocessed index column (equals the WitnessId this row binds)
     pub index: Vec<u32>,
     /// Constant values
     pub values: Vec<F>,
@@ -120,7 +120,7 @@ pub struct ConstTrace<F> {
 /// Public input table
 #[derive(Debug, Clone)]
 pub struct PublicTrace<F> {
-    /// Transparent index column (equals the WitnessId of that public)
+    /// Preprocessed index column (equals the WitnessId of that public)
     pub index: Vec<u32>,
     /// Public input values
     pub values: Vec<F>,

--- a/merkle-tree-air/src/air.rs
+++ b/merkle-tree-air/src/air.rs
@@ -197,7 +197,7 @@ pub struct MerkleVerifyCols<T, const DIGEST_ELEMS: usize, const MAX_TREE_HEIGHT:
     /// Bits of the leaf index we are currently verifying.
     pub index_bits: [T; MAX_TREE_HEIGHT],
     /// Max height of the Merkle trees, which is equal to the index's bit length.
-    /// Transparent column.
+    /// Preprocessed column.
     pub length: T,
     /// One-hot encoding of the height within the Merkle tree.
     pub height_encoding: [T; MAX_TREE_HEIGHT],
@@ -209,9 +209,9 @@ pub struct MerkleVerifyCols<T, const DIGEST_ELEMS: usize, const MAX_TREE_HEIGHT:
     /// tree verification for this index.
     pub is_final: T,
     /// Whether there is an extra step for the current height (due to batching).
-    /// Transparent column.
+    /// Preprocessed column.
     pub is_extra: T,
-    /// The height at the extra step. Transparent column.
+    /// The height at the extra step. Preprocessed column.
     pub extra_height: T,
 }
 

--- a/symmetric-air/src/sponge_air/columns.rs
+++ b/symmetric-air/src/sponge_air/columns.rs
@@ -5,11 +5,11 @@ use core::mem::size_of;
 #[repr(C)]
 pub struct SpongeCols<T, const RATE: usize, const CAPACITY: usize> {
     // Flag to clear the capacity, which will clear the state.
-    // Transparent.
+    // Preprocessed.
     pub reset: T,
     // When set to 1, the rate is overwritten by external input.
     // When set to 0, the rate is copied from the previous row.
-    // Transparent.
+    // Preprocessed.
     pub absorb: T,
 
     pub input_addresses: [T; RATE],


### PR DESCRIPTION
Just unifying terminology from Plonky3 in both code and mdbook.

closes #104 
