### PR TITLE
feat: add basic tracing and parallel support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ p3-goldilocks = { git = "https://github.com/Plonky3/Plonky3" }
 p3-keccak = { git = "https://github.com/Plonky3/Plonky3" }
 p3-koala-bear = { git = "https://github.com/Plonky3/Plonky3" }
 p3-matrix = { git = "https://github.com/Plonky3/Plonky3" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3" }
 p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3" }
 p3-symmetric = { git = "https://github.com/Plonky3/Plonky3" }
 p3-uni-stark = { git = "https://github.com/Plonky3/Plonky3" }
@@ -50,6 +51,13 @@ itertools = { version = "0.14.0", default-features = false, features = [
 rand = { version = "0.9.2", default-features = false, features = ["small_rng"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 thiserror = { version = "2.0", default-features = false }
+tracing = { version = "0.1.37", default-features = false, features = [
+    "attributes",
+] }
+tracing-forest = "0.2.0"
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
+    "alloc",
+] }
 
 # Local dependencies
 p3-challenger-air = { path = "challenger-air", version = "0.1.0" }

--- a/circuit-prover/Cargo.toml
+++ b/circuit-prover/Cargo.toml
@@ -22,17 +22,23 @@ p3-fri.workspace = true
 p3-goldilocks.workspace = true
 p3-koala-bear.workspace = true
 p3-matrix.workspace = true
+p3-maybe-rayon.workspace = true
 p3-merkle-tree.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
 postcard = { version = "1.0", default-features = false, features = ["alloc"] }
 rand.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 postcard = { version = "1.0", default-features = false, features = ["alloc"] }
 rand.workspace = true
-tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
+tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
+
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
 
 [[example]]
 name = "fibonacci"

--- a/circuit-prover/examples/fibonacci.rs
+++ b/circuit-prover/examples/fibonacci.rs
@@ -8,10 +8,28 @@ use p3_circuit_prover::config::babybear_config::build_standard_config_babybear;
 use p3_circuit_prover::prover::ProverError;
 use p3_circuit_prover::{MultiTableProver, TablePacking};
 use p3_field::PrimeCharacteristicRing;
+use tracing_forest::ForestLayer;
+use tracing_forest::util::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
 
 type F = BabyBear;
 
+fn init_logger() {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+}
+
 fn main() -> Result<(), ProverError> {
+    init_logger();
+
     let n = env::args()
         .nth(1)
         .and_then(|s| s.parse().ok())

--- a/circuit-prover/src/config.rs
+++ b/circuit-prover/src/config.rs
@@ -16,7 +16,7 @@ use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel as Dft;
 use p3_field::extension::{BinomialExtensionField, BinomiallyExtendable};
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
-use p3_fri::{TwoAdicFriPcs as Pcs, create_test_fri_params};
+use p3_fri::{TwoAdicFriPcs as Pcs, create_benchmark_fri_params};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{
     CryptographicPermutation, PaddingFreeSponge as MyHash, TruncatedPermutation as MyCompress,

--- a/circuit-prover/src/config.rs
+++ b/circuit-prover/src/config.rs
@@ -87,7 +87,7 @@ where
     let challenge_mmcs = ChallengeMmcs::<F, P, CD>::new(val_mmcs.clone());
 
     let dft = Dft::<F>::default();
-    let fri_params = create_test_fri_params::<ChallengeMmcs<F, P, CD>>(challenge_mmcs, 0);
+    let fri_params = create_benchmark_fri_params::<ChallengeMmcs<F, P, CD>>(challenge_mmcs);
     let pcs = Pcs::<F, _, _, _>::new(dft, val_mmcs, fri_params);
 
     let challenger = Challenger::<F, P, 16, 8>::new(perm);

--- a/circuit-prover/src/prover.rs
+++ b/circuit-prover/src/prover.rs
@@ -18,6 +18,7 @@ use p3_circuit::{CircuitBuilderError, CircuitError};
 use p3_field::{BasedVectorSpace, Field};
 use p3_uni_stark::{prove, verify};
 use thiserror::Error;
+use tracing::instrument;
 
 use crate::air::{AddAir, ConstAir, FakeMerkleVerifyAir, MulAir, PublicAir, WitnessAir};
 use crate::config::{ProverConfig, StarkField, StarkPermutation};
@@ -171,6 +172,7 @@ where
     /// Automatically detects whether to use base field or binomial extension field
     /// proving based on the circuit element type `EF`. For extension fields,
     /// the binomial parameter W is automatically extracted.
+    #[instrument(skip_all)]
     pub fn prove_all_tables<EF>(
         &self,
         traces: &Traces<EF>,

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -21,6 +21,7 @@ p3-uni-stark.workspace = true
 hashbrown = "0.16.0"
 serde.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 p3-air.workspace = true

--- a/circuit/src/tables.rs
+++ b/circuit/src/tables.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
+use tracing::instrument;
+
 use crate::circuit::Circuit;
 use crate::op::{NonPrimitiveOpPrivateData, Prim};
 use crate::types::{NonPrimitiveOpId, WitnessId};
@@ -181,6 +183,7 @@ impl<F: CircuitField> CircuitRunner<F> {
     }
 
     /// Run the circuit and generate traces
+    #[instrument(skip_all)]
     pub fn run(mut self) -> Result<Traces<F>, CircuitError> {
         // Step 1: Execute primitives to fill witness vector
         self.execute_primitives()?;


### PR DESCRIPTION
Added tracing logging for the `Fibonacci` example, and also added `parallel` feature to `circuit-prover` crate to leverage `rayon` from p3.