### PR TITLE
Add MMCS witness validation in circuit runner

### DIFF
--- a/circuit/src/errors.rs
+++ b/circuit/src/errors.rs
@@ -92,9 +92,12 @@ pub enum CircuitError {
     },
 
     /// Non primitive private data is not correct
-    #[error("Incorrect private data provided for op {op:?}: expected {expected}, got {got}")]
+    #[error(
+        "Incorrect private data provided for op {op:?} (operation {operation_index}): expected {expected}, got {got}"
+    )]
     IncorrectNonPrimitiveOpPrivateData {
         op: NonPrimitiveOpType,
+        operation_index: usize,
         expected: String,
         got: String,
     },


### PR DESCRIPTION
Validates that MMCS witness data (leaf and computed root) matches public inputs in `runner.run()`, catching inconsistencies early with clear error messages instead of failing later during AIR constraint checking.