### PR TITLE
circuit prover: refactor and documentation for `AddAir`

### DIFF
--- a/circuit-prover/src/air/add_air.rs
+++ b/circuit-prover/src/air/add_air.rs
@@ -124,14 +124,6 @@ impl<F: Field + PrimeCharacteristicRing, const D: usize> AddAir<F, D> {
     }
 
     /// Total number of columns in the main trace for this AIR instance.
-    ///
-    /// This is computed as
-    ///
-    /// ```text
-    /// total_width = lanes x LANE_WIDTH.
-    /// ```
-    ///
-    /// Every row of the trace matrix must have exactly this width.
     pub const fn total_width(&self) -> usize {
         self.lanes * Self::lane_width()
     }
@@ -278,9 +270,8 @@ where
         // Make sure that the matrix width matches what this AIR expects.
         debug_assert_eq!(main.width(), self.total_width(), "column width mismatch");
 
-        // Read the current row at offset 0 relative to the evaluation point.
+        // Get the evaluation at evaluation point `zeta`
         let local = main.row_slice(0).expect("matrix must be non-empty");
-        // Each lane occupies this many base-field columns.
         let lane_width = Self::lane_width();
 
         // Iterate over the row in fixed-size chunks, each chunk describing one lane:


### PR DESCRIPTION
Now that this part is a bit more stable because the addition AIR is pretty standard, I've tried to take some time to refactor and improve the documentation. So basically, the changes are:

- Documentation that explains a bit more detail (please let me know if you don't like it; I can just revert or modify it). I was mostly inspired by the way Plonky3 does it.

- I think that to transform things into field elements, we don't need to use `from_u64` but directly `from_u32` since elements are mostly already u32.

- In the `trace_to_matrix` function, I tried to avoid the double loop by using an iterator and some preallocation of the entire trace.

- In the `eval` method, I used chunking and splitting to try and simplify things compared to the old loop, which was more standard and relied on using a `cursor` to determine the position. We don't need that here.