### PR TITLE
ci: pin preprocessor versions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -25,12 +25,18 @@ jobs:
         with:
           command: install
           args: mdbook --version 0.4.52
-
-      - name: Install preprocessors
+      
+      - name: Install katex preprocessor
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: mdbook-katex mdbook-mermaid
+          args: mdbook-katex --version 0.9.4
+      
+      - name: Install mermaid preprocessor
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: mdbook-mermaid --version 0.16.0
 
       - name: Initialize mermaid preprocessor
         run: mdbook-mermaid install book


### PR DESCRIPTION
Latest `mermaid` preprocessor upgrade breaks `mdbook` build with pinned version 0.4.52 but we still need to use it because of `katex` (see #178).

Pinning both `mermaid` and `katex` versions for the time being to make sure we can build and deploy the mdbook.