### PR TITLE
perf: remove needless copy of Plonky3 Poseidon2 trace

### DIFF
--- a/recursion/src/generation.rs
+++ b/recursion/src/generation.rs
@@ -3,8 +3,6 @@ use alloc::vec::Vec;
 
 use itertools::zip_eq;
 use p3_air::Air;
-use p3_batch_stark::BatchProof;
-use p3_batch_stark::config::observe_instance_binding;
 use p3_batch_stark::config::observe_instance_binding;
 use p3_batch_stark::{BatchProof, CommonData};
 use p3_challenger::{CanObserve, CanSample, CanSampleBits, FieldChallenger, GrindingChallenger};


### PR DESCRIPTION
Should close https://github.com/Plonky3/Plonky3-recursion/issues/182

That is possible after https://github.com/Plonky3/Plonky3/pull/1159