### PR TITLE
rename: `Expr::Witness` to `Expr::Hint`

### DIFF
--- a/circuit/src/builder/compiler/expression_lowerer.rs
+++ b/circuit/src/builder/compiler/expression_lowerer.rs
@@ -195,7 +195,7 @@ where
             let expr_id = ExprId(expr_idx as u32);
             match expr {
                 Expr::Const(_) | Expr::Public(_) => { /* handled above */ }
-                Expr::Witness { is_last_hint } => {
+                Expr::Hint { is_last_hint } => {
                     let expr_id = ExprId(expr_idx as u32);
                     let out_widx = alloc_witness_id_for_expr(expr_idx);
                     expr_to_widx.insert(expr_id, out_widx);

--- a/circuit/src/builder/expression_builder.rs
+++ b/circuit/src/builder/expression_builder.rs
@@ -244,7 +244,7 @@ where
         //
         // The `is_last_hint` flag is stored in the node so the execution engine
         // can identify sequence boundaries without external metadata.
-        let expr_id = self.graph.add_expr(Expr::Witness { is_last_hint });
+        let expr_id = self.graph.add_expr(Expr::Hint { is_last_hint });
 
         // Log the allocation in debug builds.
         //
@@ -975,10 +975,10 @@ mod tests {
 
         match (&builder.graph().nodes()[2], &builder.graph().nodes()[3]) {
             (
-                Expr::Witness {
+                Expr::Hint {
                     is_last_hint: false,
                 },
-                Expr::Witness { is_last_hint: true },
+                Expr::Hint { is_last_hint: true },
             ) => (),
             _ => panic!("Expected Witness operation"),
         }

--- a/circuit/src/expr.rs
+++ b/circuit/src/expr.rs
@@ -13,7 +13,7 @@ pub enum Expr<F> {
     /// non-deterministic hint. The boolean flag indicates whether
     /// this is the last witness in a sequence of related hints,
     /// where each sequence is produced through a shared generation process.
-    Witness { is_last_hint: bool },
+    Hint { is_last_hint: bool },
     /// Addition of two expressions
     Add { lhs: ExprId, rhs: ExprId },
     /// Subtraction of two expressions


### PR DESCRIPTION
No functional change, just renaming the `Expr::Witness` to `Expr::Hint` as it may carry the underlying intended behavior better and removes any possible confusion with `PrimitiveOpType::Witness` which refers to the `Witness` Table, and not the witness hints.