### PR TITLE
recursion: rm useless `construct_stark_verifier_inputs` method

### DIFF
--- a/recursion/src/lib.rs
+++ b/recursion/src/lib.rs
@@ -21,7 +21,6 @@ pub use pcs::fri::{FriVerifierParams, MAX_QUERY_INDEX_BITS};
 pub use public_inputs::{
     BatchStarkVerifierInputsBuilder, CommitmentOpening, FriVerifierInputs, PublicInputBuilder,
     StarkVerifierInputs, StarkVerifierInputsBuilder, construct_batch_stark_verifier_inputs,
-    construct_stark_verifier_inputs,
 };
 pub use traits::{
     Recursive, RecursiveAir, RecursiveChallenger, RecursiveExtensionMmcs, RecursiveMmcs,

--- a/recursion/src/prelude.rs
+++ b/recursion/src/prelude.rs
@@ -15,7 +15,7 @@ pub use crate::generation::{GenerationError, PcsGeneration, generate_challenges}
 pub use crate::pcs::fri::{FriVerifierParams, MAX_QUERY_INDEX_BITS};
 pub use crate::public_inputs::{
     CommitmentOpening, FriVerifierInputs, PublicInputBuilder, StarkVerifierInputs,
-    StarkVerifierInputsBuilder, construct_stark_verifier_inputs,
+    StarkVerifierInputsBuilder,
 };
 pub use crate::traits::{
     ComsWithOpeningsTargets, Recursive, RecursiveAir, RecursiveChallenger, RecursiveExtensionMmcs,

--- a/recursion/src/public_inputs.rs
+++ b/recursion/src/public_inputs.rs
@@ -564,13 +564,14 @@ where
             .map_or_else(Vec::new, |prep_comm| Comm::get_values(prep_comm));
 
         // Combine all components into a single public input vector.
-        construct_stark_verifier_inputs(
-            air_public_values,
-            &proof_values,
-            &preprocessed,
-            challenges,
+        StarkVerifierInputs {
+            air_public_values: air_public_values.to_vec(),
+            proof_values: proof_values.to_vec(),
+            preprocessed: preprocessed.to_vec(),
+            challenges: challenges.to_vec(),
             num_queries,
-        )
+        }
+        .build()
     }
 }
 


### PR DESCRIPTION
As mentioned here https://github.com/Plonky3/Plonky3-recursion/pull/201#discussion_r2571453808 the builder pattern is already very explicit so we probably don't need this method.

Feel free to close if you feel the PR is not appropriate.