### PR TITLE
fix: make coverage job work

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: gh-pages


### PR DESCRIPTION
Current coverage job fails to publish results because of permissions issues.

This seems to be due to the `contents: read` permission as we were pushing to the `gh-pages` branch.
Note that `pages: write` may be not needed as we don't proceed to regular deployment, but I'm not sure.

related to #227 (will close once the job actually runs properly)