### PR TITLE
naming: remove `add_` prefix in expression builder functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ Both examples use the unified API (`prove_next_layer`, `RecursionInput`, `FriRec
 The `CircuitBuilder<F>` provides a modular API for building circuits:
 
 **Primitive Operations** (always available):
-- `add_const(val)` - Add a constant
-- `add_public_input()` - Allocate a public input
+- `define_const(val)` - Add a constant
+- `public_input()` - Allocate a public input
 - `mul(a, b)` - Multiply two expressions
 - `add(a, b)` / `sub(a, b)` - Arithmetic operations
 - `connect(a, b)` - Constrain two expressions to be equal

--- a/book/src/advanced_topics/debugging.md
+++ b/book/src/advanced_topics/debugging.md
@@ -30,7 +30,7 @@ let a_plus_bc = builder.alloc_add(input_a, b_times_c, "a_plus_bc");
 let a_minus_bc = builder.alloc_sub(input_a, b_times_c, "a_minus_bc");
 
 // Default allocation
-let x = builder.add_public_input(); // unlabelled
+let x = builder.public_input(); // unlabelled
 let y = builder.add(x, z);          // unlabelled
 ```
 

--- a/book/src/architecture_and_internals/circuit_building.md
+++ b/book/src/architecture_and_internals/circuit_building.md
@@ -7,11 +7,11 @@ We’ll use a simple Fibonacci example throughout this page to ground the ideas 
 let mut builder = CircuitBuilder::<F>::new();
 
 // Public input: expected F(n)
-let expected_result = builder.add_public_input();
+let expected_result = builder.public_input();
 
 // Compute F(n) iteratively
-let mut a = builder.add_const(F::ZERO); // F(0)
-let mut b = builder.add_const(F::ONE);  // F(1)
+let mut a = builder.define_const(F::ZERO); // F(0)
+let mut b = builder.define_const(F::ONE);  // F(1)
 
 for _i in 2..=n {
     let next = builder.add(a, b); // F(N) <- F(N-1) + F(N-2)
@@ -62,7 +62,7 @@ We can consider a small example to show how operations are mapped. Given public 
 
 ```rust,ignore
 // We get the `ExprId` corresponding to Const{ c } by adding a constant to the circuit.
-let x = builder.add_const(c);
+let x = builder.define_const(c);
 // We use the previously computed `x` to compute the subtraction in the circuit.
 let y = builder.sub(b, x);
 // We use the previously computed `y` to compute the multiplication in the circuit.
@@ -91,7 +91,7 @@ fn eval_folded_circuit(
             get_symbolic_constraints(self, 0, columns.public_values.len());
 
         // Fold all the constraints using the folding challenge.
-        let mut acc = builder.add_const(F::ZERO);
+        let mut acc = builder.define_const(F::ZERO);
         for s_c in symbolic_constraints {
             let mul_prev = builder.mul(acc, *alpha);
 

--- a/book/src/trace_generation.md
+++ b/book/src/trace_generation.md
@@ -55,9 +55,9 @@ Consider a simple Fibonacci circuit computing `F(5)`:
 ```rust,ignore
 let mut builder = CircuitBuilder::new();
 
-let expected = builder.add_public_input();
-let mut a = builder.add_const(F::ZERO);
-let mut b = builder.add_const(F::ONE);
+let expected = builder.public_input();
+let mut a = builder.define_const(F::ZERO);
+let mut b = builder.define_const(F::ONE);
 
 for _ in 2..=5 {
     let next = builder.add(a, b);

--- a/circuit-prover/examples/poseidon2_perm_merkle.rs
+++ b/circuit-prover/examples/poseidon2_perm_merkle.rs
@@ -181,9 +181,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // All inputs are private (chained from row 0 or provided via private data)
     let sibling1_inputs: [Option<ExprId>; 4] = [None, None, None, None];
     // Public root limbs
-    let out0 = builder.add_public_input();
-    let out1 = builder.add_public_input();
-    let mmcs_idx_sum_expr = builder.add_public_input();
+    let out0 = builder.public_input();
+    let out1 = builder.public_input();
+    let mmcs_idx_sum_expr = builder.public_input();
 
     let mmcs_bit_row1 = builder.alloc_const(Ext4::from_prime_subfield(Base::ONE), "mmcs_bit_row1");
     let (row1_op_id, _row1_outputs) =

--- a/circuit-prover/src/batch_stark_prover/tests.rs
+++ b/circuit-prover/src/batch_stark_prover/tests.rs
@@ -14,12 +14,12 @@ fn test_babybear_batch_stark_base_field() {
     let mut builder = CircuitBuilder::<BabyBear>::new();
 
     // x + 5*2 - 3 + (-1) == expected
-    let x = builder.add_public_input();
-    let expected = builder.add_public_input();
-    let c5 = builder.add_const(BabyBear::from_u64(5));
-    let c2 = builder.add_const(BabyBear::from_u64(2));
-    let c3 = builder.add_const(BabyBear::from_u64(3));
-    let neg_one = builder.add_const(BabyBear::NEG_ONE);
+    let x = builder.public_input();
+    let expected = builder.public_input();
+    let c5 = builder.define_const(BabyBear::from_u64(5));
+    let c2 = builder.define_const(BabyBear::from_u64(2));
+    let c3 = builder.define_const(BabyBear::from_u64(3));
+    let neg_one = builder.define_const(BabyBear::NEG_ONE);
 
     let mul_result = builder.mul(c5, c2); // 10
     let add_result = builder.add(x, mul_result); // x + 10
@@ -70,12 +70,12 @@ fn test_table_lookups() {
     let cfg = config::baby_bear().build();
 
     // x + 5*2 - 3 + (-1) == expected
-    let x = builder.add_public_input();
-    let expected = builder.add_public_input();
-    let c5 = builder.add_const(BabyBear::from_u64(5));
-    let c2 = builder.add_const(BabyBear::from_u64(2));
-    let c3 = builder.add_const(BabyBear::from_u64(3));
-    let neg_one = builder.add_const(BabyBear::NEG_ONE);
+    let x = builder.public_input();
+    let expected = builder.public_input();
+    let c5 = builder.define_const(BabyBear::from_u64(5));
+    let c2 = builder.define_const(BabyBear::from_u64(2));
+    let c3 = builder.define_const(BabyBear::from_u64(3));
+    let neg_one = builder.define_const(BabyBear::NEG_ONE);
 
     let mul_result = builder.mul(c5, c2); // 10
     let add_result = builder.add(x, mul_result); // x + 10
@@ -197,10 +197,10 @@ fn test_extension_field_batch_stark() {
     let cfg = config::baby_bear().build();
 
     let mut builder = CircuitBuilder::<Ext4>::new();
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
-    let z = builder.add_public_input();
-    let expected = builder.add_public_input();
+    let x = builder.public_input();
+    let y = builder.public_input();
+    let z = builder.public_input();
+    let expected = builder.public_input();
     let xy = builder.mul(x, y);
     let res = builder.add(xy, z);
     let diff = builder.sub(res, expected);
@@ -265,10 +265,10 @@ fn test_extension_field_table_lookups() {
     let cfg = config::baby_bear().build();
 
     let mut builder = CircuitBuilder::<Ext4>::new();
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
-    let z = builder.add_public_input();
-    let expected = builder.add_public_input();
+    let x = builder.public_input();
+    let y = builder.public_input();
+    let z = builder.public_input();
+    let expected = builder.public_input();
     let xy = builder.mul(x, y);
     let res = builder.add(xy, z);
     let diff = builder.sub(res, expected);
@@ -410,11 +410,11 @@ fn test_koalabear_batch_stark_base_field() {
     let cfg = config::koala_bear().build();
 
     // a * b + 100 - (-1) == expected
-    let a = builder.add_public_input();
-    let b = builder.add_public_input();
-    let expected = builder.add_public_input();
-    let c = builder.add_const(KoalaBear::from_u64(100));
-    let d = builder.add_const(KoalaBear::NEG_ONE);
+    let a = builder.public_input();
+    let b = builder.public_input();
+    let expected = builder.public_input();
+    let c = builder.define_const(KoalaBear::from_u64(100));
+    let d = builder.define_const(KoalaBear::NEG_ONE);
 
     let ab = builder.mul(a, b);
     let add = builder.add(ab, c);
@@ -462,10 +462,10 @@ fn test_koalabear_batch_stark_extension_field_d8() {
     let cfg = config::koala_bear().build();
 
     // x * y * z == expected
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
-    let expected = builder.add_public_input();
-    let z = builder.add_const(
+    let x = builder.public_input();
+    let y = builder.public_input();
+    let expected = builder.public_input();
+    let z = builder.define_const(
         KBExtField::from_basis_coefficients_slice(&[
             KoalaBear::from_u64(1),
             KoalaBear::NEG_ONE,
@@ -557,10 +557,10 @@ fn test_goldilocks_batch_stark_extension_field_d2() {
     let cfg = config::goldilocks().build();
 
     // x * y + z == expected
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
-    let z = builder.add_public_input();
-    let expected = builder.add_public_input();
+    let x = builder.public_input();
+    let y = builder.public_input();
+    let z = builder.public_input();
+    let expected = builder.public_input();
 
     let xy = builder.mul(x, y);
     let res = builder.add(xy, z);
@@ -663,8 +663,8 @@ fn test_mul_only_circuit_padding() {
     let mut builder = CircuitBuilder::<BabyBear>::new();
     let cfg = config::baby_bear().build();
 
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
+    let x = builder.public_input();
+    let y = builder.public_input();
 
     // Only multiplication, no addition
     builder.mul(x, y);
@@ -704,9 +704,9 @@ fn test_add_only_circuit_padding() {
     let mut builder = CircuitBuilder::<BabyBear>::new();
     let cfg = config::baby_bear().build();
 
-    let x = builder.add_public_input();
-    let y = builder.add_public_input();
-    let expected = builder.add_public_input();
+    let x = builder.public_input();
+    let y = builder.public_input();
+    let expected = builder.public_input();
 
     // Only addition, no multiplication
     let sum = builder.add(x, y);

--- a/circuit-prover/src/lib.rs
+++ b/circuit-prover/src/lib.rs
@@ -20,10 +20,10 @@
 //! use p3_circuit_prover::BatchStarkProver;
 //!
 //! let mut builder = CircuitBuilder::<BabyBear>::new();
-//! let x = builder.add_public_input();
-//! let y = builder.add_public_input();
+//! let x = builder.public_input();
+//! let y = builder.public_input();
 //! let z = builder.add(x, y);
-//! builder.assert_zero(builder.sub(z, builder.add_const(BabyBear::from_u64(3))));
+//! builder.assert_zero(builder.sub(z, builder.define_const(BabyBear::from_u64(3))));
 //! let circuit = builder.build();
 //! let mut runner = circuit.runner();
 //! runner.set_public_inputs(&[BabyBear::from_u64(1), BabyBear::from_u64(2)]).unwrap();

--- a/circuit/src/builder/compiler/optimizer.rs
+++ b/circuit/src/builder/compiler/optimizer.rs
@@ -1017,9 +1017,9 @@ mod tests {
     #[test]
     fn test_duplicated_op_fusion_in_builder() {
         let mut builder = CircuitBuilder::<F>::new();
-        let a = builder.add_const(F::TWO);
-        let b = builder.add_public_input();
-        let c = builder.add_public_input();
+        let a = builder.define_const(F::TWO);
+        let b = builder.public_input();
+        let c = builder.public_input();
 
         builder.connect(b, c);
 

--- a/circuit/src/ops/hash.rs
+++ b/circuit/src/ops/hash.rs
@@ -106,7 +106,7 @@ mod tests {
             let input_exprs: Vec<ExprId> = (0..base_inputs.len())
                 .chunks(<CF as BasedVectorSpace<F>>::DIMENSION)
                 .into_iter()
-                .map(|_| builder.add_public_input())
+                .map(|_| builder.public_input())
                 .collect();
 
             let outputs = add_hash_slice(
@@ -117,8 +117,8 @@ mod tests {
             )
             .unwrap();
 
-            let out0_pi = builder.add_public_input();
-            let out1_pi = builder.add_public_input();
+            let out0_pi = builder.public_input();
+            let out1_pi = builder.public_input();
             builder.connect(outputs[0], out0_pi);
             builder.connect(outputs[1], out1_pi);
 
@@ -180,7 +180,7 @@ mod tests {
         // Pack base inputs into extension elements (will zero-pad the last one)
         let input_exprs: Vec<ExprId> = base_inputs
             .chunks(<CF as BasedVectorSpace<F>>::DIMENSION)
-            .map(|_| builder.add_public_input())
+            .map(|_| builder.public_input())
             .collect();
 
         let outputs = add_hash_slice(
@@ -191,8 +191,8 @@ mod tests {
         )
         .unwrap();
 
-        let out0_pi = builder.add_public_input();
-        let out1_pi = builder.add_public_input();
+        let out0_pi = builder.public_input();
+        let out1_pi = builder.public_input();
         builder.connect(outputs[0], out0_pi);
         builder.connect(outputs[1], out1_pi);
 

--- a/circuit/src/ops/mmcs.rs
+++ b/circuit/src/ops/mmcs.rs
@@ -88,7 +88,7 @@ pub fn add_mmcs_verify<F: Field>(
     // We return only the operations that require private data.
     let mut op_ids = Vec::with_capacity(openings_expr.len());
     let mut output = [None, None, None, None];
-    let zero = builder.add_const(F::ZERO);
+    let zero = builder.define_const(F::ZERO);
 
     // Detect a non-empty tail digest (cap-level rows to inject after the main path).
     let has_tail = openings_expr.len() > directions_expr.len()

--- a/circuit/src/tables/runner.rs
+++ b/circuit/src/tables/runner.rs
@@ -421,8 +421,8 @@ mod tests {
         let mut builder = CircuitBuilder::new();
 
         // Simple test: x + 5 = result
-        let x = builder.add_public_input();
-        let c5 = builder.add_const(BabyBear::from_u64(5));
+        let x = builder.public_input();
+        let c5 = builder.define_const(BabyBear::from_u64(5));
         let _result = builder.add(x, c5);
 
         let circuit = builder.build().unwrap();
@@ -494,8 +494,8 @@ mod tests {
 
         let mut builder = CircuitBuilder::new();
 
-        let c37 = builder.add_const(BabyBear::from_u64(37));
-        let c111 = builder.add_const(BabyBear::from_u64(111));
+        let c37 = builder.define_const(BabyBear::from_u64(37));
+        let c111 = builder.define_const(BabyBear::from_u64(111));
         let x_hint = XHint::new();
         let x = builder
             .push_unconstrained_op(vec![vec![c37, c111]], 1, x_hint, "x")
@@ -544,9 +544,9 @@ mod tests {
         let mut builder = CircuitBuilder::new();
 
         // Test extension field operations: x + y * z
-        let x = builder.add_public_input();
-        let y = builder.add_public_input();
-        let z = builder.add_public_input();
+        let x = builder.public_input();
+        let y = builder.public_input();
+        let z = builder.public_input();
 
         let yz = builder.mul(y, z);
         let _result = builder.add(x, yz);

--- a/circuit/src/utils.rs
+++ b/circuit/src/utils.rs
@@ -141,7 +141,7 @@ fn symbolic_to_circuit_core<CF: Field, F: Field>(
                 }
                 match expr {
                     SymbolicExpression::Constant(c) => {
-                        let id = circuit.add_const(convert_const(*c));
+                        let id = circuit.define_const(convert_const(*c));
                         cache.insert(key, id);
                         stack.push(id);
                     }
@@ -212,7 +212,7 @@ fn symbolic_to_circuit_core<CF: Field, F: Field>(
                     Op::Sub => circuit.sub(lhs, rhs),
                     Op::Mul => circuit.mul(lhs, rhs),
                     Op::Neg => {
-                        let zero = circuit.add_const(F::ZERO);
+                        let zero = circuit.define_const(F::ZERO);
                         circuit.sub(zero, rhs)
                     }
                 };
@@ -334,20 +334,20 @@ mod tests {
         // Build a circuit adding public inputs for `sels`, public values, local values and next values.
         let mut circuit = CircuitBuilder::new();
         let circuit_sels = [
-            circuit.add_public_input(),
-            circuit.add_public_input(),
-            circuit.add_public_input(),
+            circuit.public_input(),
+            circuit.public_input(),
+            circuit.public_input(),
         ];
         let circuit_public_values = [
-            circuit.add_public_input(),
-            circuit.add_public_input(),
-            circuit.add_public_input(),
+            circuit.public_input(),
+            circuit.public_input(),
+            circuit.public_input(),
         ];
         let mut circuit_local_values = Vec::with_capacity(NUM_FIBONACCI_COLS);
         let mut circuit_next_values = Vec::with_capacity(NUM_FIBONACCI_COLS);
         for _ in 0..NUM_FIBONACCI_COLS {
-            circuit_local_values.push(circuit.add_public_input());
-            circuit_next_values.push(circuit.add_public_input());
+            circuit_local_values.push(circuit.public_input());
+            circuit_next_values.push(circuit.public_input());
         }
 
         let row_selectors = RowSelectorsTargets {
@@ -376,7 +376,7 @@ mod tests {
         );
 
         // Check that the circuit output equals the folded constraints.
-        let final_result_const = circuit.add_const(folded_constraints);
+        let final_result_const = circuit.define_const(folded_constraints);
         circuit.connect(final_result_const, sum);
 
         let mut all_public_values = sels.to_vec();

--- a/recursion/src/challenger/circuit.rs
+++ b/recursion/src/challenger/circuit.rs
@@ -84,7 +84,7 @@ impl<const WIDTH: usize, const RATE: usize> CircuitChallenger<WIDTH, RATE> {
         if self.initialized {
             return;
         }
-        let zero = circuit.add_const(EF::ZERO);
+        let zero = circuit.define_const(EF::ZERO);
         self.state = vec![zero; WIDTH];
         self.initialized = true;
     }
@@ -313,7 +313,7 @@ where
     }
 
     fn clear(&mut self, circuit: &mut CircuitBuilder<EF>) {
-        let zero = circuit.add_const(EF::ZERO);
+        let zero = circuit.define_const(EF::ZERO);
         self.state = vec![zero; WIDTH];
         self.input_buffer.clear();
         self.output_buffer.clear();

--- a/recursion/src/pcs/fri/targets.rs
+++ b/recursion/src/pcs/fri/targets.rs
@@ -205,7 +205,7 @@ impl<F: Field, EF: ExtensionField<F> + BasedVectorSpace<F>, RecMmcs: RecursiveEx
 
         let mut result = coeffs[0];
         for (i, &basis_elem) in basis.iter().enumerate().skip(1) {
-            let basis_const = circuit.add_const(basis_elem);
+            let basis_const = circuit.define_const(basis_elem);
             let term = circuit.mul(coeffs[i], basis_const);
             result = circuit.add(result, term);
         }

--- a/recursion/src/pcs/mmcs.rs
+++ b/recursion/src/pcs/mmcs.rs
@@ -41,7 +41,7 @@ where
 {
     if base_coeffs.is_empty() {
         // Return zeros for empty input (shouldn't happen in practice)
-        let zero = circuit.add_const(EF::ZERO);
+        let zero = circuit.define_const(EF::ZERO);
         return Ok(vec![zero, zero]);
     }
 
@@ -99,7 +99,7 @@ where
                         ext_coeffs.push(prev[coeff_idx]);
                     } else {
                         // First permutation with new_start, use zero
-                        ext_coeffs.push(circuit.add_const(EF::ZERO));
+                        ext_coeffs.push(circuit.define_const(EF::ZERO));
                     }
                 }
 
@@ -155,11 +155,11 @@ where
 {
     let rate_ext = permutation_config.rate_ext();
     if ext_elements.is_empty() {
-        let zero = circuit.add_const(EF::ZERO);
+        let zero = circuit.define_const(EF::ZERO);
         return Ok(vec![zero, zero]);
     }
 
-    let zero = circuit.add_const(EF::ZERO);
+    let zero = circuit.define_const(EF::ZERO);
     let mut last_rate_outputs: Option<[Target; 2]> = None;
     let mut final_outputs = [None, None, None, None];
 
@@ -674,7 +674,7 @@ mod test {
                 .iter()
                 .map(|opening| {
                     (0..opening.len())
-                        .map(|_| builder.add_public_input())
+                        .map(|_| builder.public_input())
                         .collect_vec()
                 })
                 .collect_vec();
@@ -980,7 +980,7 @@ mod test {
             .map(|mat_hash| {
                 mat_hash
                     .iter()
-                    .map(|_| builder.add_public_input())
+                    .map(|_| builder.public_input())
                     .collect_vec()
             })
             .collect_vec();
@@ -1106,12 +1106,7 @@ mod test {
             let lifted_openings: Vec<Vec<_>> = batch_opening
                 .opened_values
                 .iter()
-                .map(|values| {
-                    values
-                        .iter()
-                        .map(|_| builder.add_public_input())
-                        .collect_vec()
-                })
+                .map(|values| values.iter().map(|_| builder.public_input()).collect_vec())
                 .collect();
 
             let directions_expr = builder.alloc_public_inputs(log_max_height, "directions");
@@ -1121,7 +1116,7 @@ mod test {
             let mut cap_exprs = Vec::with_capacity(cap_len);
             for _ in 0..cap_len {
                 let lifted: Vec<_> = (0..permutation_config.rate())
-                    .map(|_| builder.add_public_input())
+                    .map(|_| builder.public_input())
                     .collect();
                 let packed = pack_lifted_targets::<F, CF>(&mut builder, &lifted);
                 cap_exprs.push(packed);
@@ -1217,11 +1212,10 @@ mod test {
         lifted
             .chunks(d)
             .map(|chunk| {
-                let mut acc = builder.add_const(EF::ZERO);
+                let mut acc = builder.define_const(EF::ZERO);
                 for (i, &target) in chunk.iter().enumerate() {
-                    let basis_const = builder.add_const(basis[i]);
-                    let term = builder.mul(target, basis_const);
-                    acc = builder.add(acc, term);
+                    let basis_const = builder.define_const(basis[i]);
+                    acc = builder.mul_add(target, basis_const, acc);
                 }
                 acc
             })
@@ -1269,12 +1263,7 @@ mod test {
             let lifted_openings: Vec<Vec<_>> = batch_opening
                 .opened_values
                 .iter()
-                .map(|values| {
-                    values
-                        .iter()
-                        .map(|_| builder.add_public_input())
-                        .collect_vec()
-                })
+                .map(|values| values.iter().map(|_| builder.public_input()).collect_vec())
                 .collect();
 
             let directions_expr = builder.alloc_public_inputs(log_max_height, "directions");
@@ -1284,7 +1273,7 @@ mod test {
             let mut cap_exprs = Vec::with_capacity(cap_len);
             for _ in 0..cap_len {
                 let lifted: Vec<_> = (0..permutation_config.rate())
-                    .map(|_| builder.add_public_input())
+                    .map(|_| builder.public_input())
                     .collect();
                 let packed = pack_lifted_targets::<F, CF>(&mut builder, &lifted);
                 cap_exprs.push(packed);

--- a/recursion/src/public_inputs.rs
+++ b/recursion/src/public_inputs.rs
@@ -492,7 +492,7 @@ where
         //
         // These targets come first in the overall public input ordering.
         let air_public_targets = (0..num_air_public_inputs)
-            .map(|_| circuit.add_public_input())
+            .map(|_| circuit.public_input())
             .collect();
 
         // Allocate targets for all proof components based on the reference proof.
@@ -626,7 +626,7 @@ where
         // For each instance, allocate `count` public input targets.
         let air_public_targets = air_public_counts
             .iter()
-            .map(|&count| (0..count).map(|_| circuit.add_public_input()).collect())
+            .map(|&count| (0..count).map(|_| circuit.public_input()).collect())
             .collect();
 
         // Allocate targets for the batch proof structure, based on the reference proof.

--- a/recursion/src/recursion.rs
+++ b/recursion/src/recursion.rs
@@ -178,7 +178,7 @@ impl<F: Field, EF: ExtensionField<F>, LG: LookupGadget> RecursiveAir<F, EF, LG> 
         _columns: ColumnsTargets<'_>,
         _lookup_gadget: &LG,
     ) -> Target {
-        builder.add_const(EF::ZERO)
+        builder.define_const(EF::ZERO)
     }
 
     fn get_log_num_quotient_chunks(

--- a/recursion/src/traits/air.rs
+++ b/recursion/src/traits/air.rs
@@ -141,7 +141,7 @@ where
         //
         // Additionally, the cache is shared across all constraint calls to reuse circuit
         // operations for sub-expressions shared between different constraints.
-        let mut acc = builder.add_const(EF::ZERO);
+        let mut acc = builder.define_const(EF::ZERO);
         let mut base_cache = HashMap::new();
         for s_c in &base_symbolic_constraints {
             let mul_prev = builder.mul(acc, *alpha);

--- a/recursion/src/traits/recursive.rs
+++ b/recursion/src/traits/recursive.rs
@@ -61,7 +61,7 @@ impl<F: Field> RecursiveLookupGadget<F> for LogUpGadget {
         circuit: &mut CircuitBuilder<F>,
         all_expected_cumulative: &[Target],
     ) {
-        let mut final_cumulative = circuit.add_const(F::ZERO);
+        let mut final_cumulative = circuit.define_const(F::ZERO);
         for a_e_c in all_expected_cumulative {
             final_cumulative = circuit.add(final_cumulative, *a_e_c);
         }

--- a/recursion/src/types/challenges.rs
+++ b/recursion/src/types/challenges.rs
@@ -146,7 +146,7 @@ impl StarkChallenges {
 
         // 11. Compute zeta_next = zeta * trace_domain_generator (NOT sampled!)
         // This matches native behavior: zeta_next = init_trace_domain.next_point(zeta)
-        let generator_const = circuit.add_const(params.trace_domain_generator);
+        let generator_const = circuit.define_const(params.trace_domain_generator);
         let zeta_next = circuit.mul(zeta, generator_const);
 
         Self {

--- a/recursion/src/verifier/batch_stark.rs
+++ b/recursion/src/verifier/batch_stark.rs
@@ -779,7 +779,7 @@ where
                 )
             })?;
             let generator = next_point * first_point.inverse();
-            let generator_const = circuit.add_const(generator);
+            let generator_const = circuit.define_const(generator);
             let zeta_next = circuit.mul(zeta, generator_const);
             Ok((
                 *ext_dom,
@@ -888,7 +888,7 @@ where
                 )
             })?;
             let generator = next_point * first_point.inverse();
-            let generator_const = circuit.add_const(generator);
+            let generator_const = circuit.define_const(generator);
             let zeta_next = circuit.mul(zeta, generator_const);
 
             pre_round.push((
@@ -928,7 +928,7 @@ where
                     )
                 })?;
                 let generator = next_point * first_point.inverse();
-                let generator_const = circuit.add_const(generator);
+                let generator_const = circuit.define_const(generator);
                 let zeta_next = circuit.mul(zeta, generator_const);
 
                 permutation_round.push((
@@ -1016,10 +1016,10 @@ where
             // Each chunk represents the coefficients of one extension field element.
             flat.chunks_exact(ext_degree)
                 .map(|coeffs| {
-                    let mut sum = circuit.add_const(SC::Challenge::ZERO);
+                    let mut sum = circuit.define_const(SC::Challenge::ZERO);
                     // Dot product: sum(coeff_j * basis_j)
                     coeffs.iter().enumerate().for_each(|(j, &coeff)| {
-                        let e_i = circuit.add_const(
+                        let e_i = circuit.define_const(
                             SC::Challenge::ith_basis_element(j)
                                 .expect("Basis element should exist"),
                         );

--- a/recursion/src/verifier/quotient.rs
+++ b/recursion/src/verifier/quotient.rs
@@ -242,7 +242,7 @@ where
     // Pre-lift all denominator constants once before the loop
     let den_targets: Vec<_> = den_constants
         .iter()
-        .map(|&c| circuit.add_const(c))
+        .map(|&c| circuit.define_const(c))
         .collect();
 
     // For each chunk i, compute L_i(ζ) = [∏_j Z_j(ζ) / Z_i(ζ)] / den_i
@@ -304,7 +304,7 @@ where
 
     // Handle edge cases: empty chunks or trivial extension
     if d == 0 || opened_quotient_chunks.is_empty() {
-        return circuit.add_const(SC::Challenge::ZERO);
+        return circuit.define_const(SC::Challenge::ZERO);
     }
 
     // Phase 1: Pre-compute extension field basis elements
@@ -316,7 +316,7 @@ where
         .map(|i| {
             let basis_elem =
                 SC::Challenge::ith_basis_element(i).expect("Basis index should be in range [0, d)");
-            circuit.add_const(basis_elem)
+            circuit.define_const(basis_elem)
         })
         .collect();
 
@@ -391,7 +391,7 @@ where
     // Normalize: compute point/g where g is the coset generator
     //
     // Cost: 1 multiplication constraint
-    let inv = circuit.add_const(pcs.first_point(domain).inverse());
+    let inv = circuit.define_const(pcs.first_point(domain).inverse());
     let mul = circuit.mul(point, inv);
 
     // Exponentiate: compute (point/g)^n where n = 2^(log_size)
@@ -402,6 +402,6 @@ where
     // Subtract: Z_H(point) = (point/g)^n - 1
     //
     // Cost: 1 subtraction constraint
-    let one = circuit.add_const(SC::Challenge::ONE);
+    let one = circuit.define_const(SC::Challenge::ONE);
     circuit.sub(exp, one)
 }

--- a/recursion/tests/air_symbolic_to_circuit.rs
+++ b/recursion/tests/air_symbolic_to_circuit.rs
@@ -76,22 +76,22 @@ where
 
     let mut builder = CircuitBuilder::<F>::new();
     let selector_targets = [
-        builder.add_public_input(),
-        builder.add_public_input(),
-        builder.add_public_input(),
+        builder.public_input(),
+        builder.public_input(),
+        builder.public_input(),
     ];
     let public_targets: Vec<_> = (0..num_public_values)
-        .map(|_| builder.add_public_input())
+        .map(|_| builder.public_input())
         .collect();
 
     let pre_local_targets: Vec<_> = (0..preprocessed_width)
-        .map(|_| builder.add_public_input())
+        .map(|_| builder.public_input())
         .collect();
     let pre_next_targets: Vec<_> = (0..preprocessed_width)
-        .map(|_| builder.add_public_input())
+        .map(|_| builder.public_input())
         .collect();
-    let local_targets: Vec<_> = (0..width).map(|_| builder.add_public_input()).collect();
-    let next_targets: Vec<_> = (0..width).map(|_| builder.add_public_input()).collect();
+    let local_targets: Vec<_> = (0..width).map(|_| builder.public_input()).collect();
+    let next_targets: Vec<_> = (0..width).map(|_| builder.public_input()).collect();
 
     let row_selectors = RowSelectorsTargets {
         is_first_row: selector_targets[0],
@@ -110,10 +110,10 @@ where
         next_values: &next_targets,
     };
 
-    let alpha_t = builder.add_const(alpha);
+    let alpha_t = builder.define_const(alpha);
     let sels = RecursiveLagrangeSelectors {
         row_selectors,
-        inv_vanishing: builder.add_const(F::ONE),
+        inv_vanishing: builder.define_const(F::ONE),
     };
     let lookup_gadget = LogUpGadget {};
     let dummy_lookup_metadata = LookupMetadata {
@@ -128,7 +128,7 @@ where
         columns,
         &lookup_gadget,
     );
-    let const_target = builder.add_const(folded_value);
+    let const_target = builder.define_const(folded_value);
     builder.connect(const_target, sum);
 
     let mut all_public_inputs = Vec::new();

--- a/recursion/tests/fri.rs
+++ b/recursion/tests/fri.rs
@@ -411,16 +411,14 @@ fn run_fri_test(setup: FriSetup, build_only: bool) {
     );
 
     // 2) Public inputs for α, βs, index bits
-    let alpha_t = builder.add_public_input();
-    let betas_t: Vec<_> = (0..num_phases)
-        .map(|_| builder.add_public_input())
-        .collect();
+    let alpha_t = builder.public_input();
+    let betas_t: Vec<_> = (0..num_phases).map(|_| builder.public_input()).collect();
 
     let num_queries = result_1.index_bits_per_query.len();
     let index_bits_t_per_query: Vec<Vec<_>> = (0..num_queries)
         .map(|_| {
             (0..log_max_height)
-                .map(|_| builder.add_public_input())
+                .map(|_| builder.public_input())
                 .collect()
         })
         .collect();
@@ -432,14 +430,14 @@ fn run_fri_test(setup: FriSetup, build_only: bool) {
     let mut commitments_with_opening_points_targets = Vec::new();
     for (_commit_val, mats_data) in &result_1.commitments_with_points {
         // Allocate commitment target (placeholder, not used in arithmetic verification)
-        let commit_t = builder.add_public_input();
+        let commit_t = builder.public_input();
 
         let mut mats_targets = Vec::new();
         for (domain, points_and_values) in mats_data {
             let mut pv_targets = Vec::new();
             for (_z, fz) in points_and_values {
-                let z_t = builder.add_public_input();
-                let fz_t: Vec<_> = (0..fz.len()).map(|_| builder.add_public_input()).collect();
+                let z_t = builder.public_input();
+                let fz_t: Vec<_> = (0..fz.len()).map(|_| builder.public_input()).collect();
                 pv_targets.push((z_t, fz_t));
             }
             mats_targets.push((*domain, pv_targets));
@@ -579,15 +577,13 @@ fn run_fri_test_with_mmcs(setup: FriSetup) {
     let fri_targets = FriTargets::new(&mut builder, &result.fri_proof);
 
     // 2) Public inputs for α, βs, index bits
-    let alpha_t = builder.add_public_input();
-    let betas_t: Vec<_> = (0..num_phases)
-        .map(|_| builder.add_public_input())
-        .collect();
+    let alpha_t = builder.public_input();
+    let betas_t: Vec<_> = (0..num_phases).map(|_| builder.public_input()).collect();
 
     let index_bits_t_per_query: Vec<Vec<_>> = (0..num_queries)
         .map(|_| {
             (0..log_max_height)
-                .map(|_| builder.add_public_input())
+                .map(|_| builder.public_input())
                 .collect()
         })
         .collect();
@@ -633,8 +629,8 @@ fn run_fri_test_with_mmcs(setup: FriSetup) {
         for (domain, points_and_values) in mats_data {
             let mut pv_targets = Vec::new();
             for (_z, fz) in points_and_values {
-                let z_t = builder.add_public_input();
-                let fz_t: Vec<_> = (0..fz.len()).map(|_| builder.add_public_input()).collect();
+                let z_t = builder.public_input();
+                let fz_t: Vec<_> = (0..fz.len()).map(|_| builder.public_input()).collect();
                 pv_targets.push((z_t, fz_t));
             }
             mats_targets.push((*domain, pv_targets));

--- a/recursion/tests/test_lookups.rs
+++ b/recursion/tests/test_lookups.rs
@@ -770,10 +770,10 @@ fn get_verifier_inputs_and_challenges(
 fn get_circuit(n: usize) -> CircuitBuilder<F> {
     let mut builder = CircuitBuilder::<F>::new();
 
-    let x = builder.add_public_input();
-    let a = builder.add_public_input();
-    let b = builder.add_public_input();
-    let expected_result = builder.add_public_input();
+    let x = builder.public_input();
+    let a = builder.public_input();
+    let b = builder.public_input();
+    let expected_result = builder.public_input();
 
     // y = a * x + b
     let mut y = builder.mul(a, x);
@@ -802,8 +802,8 @@ fn test_poseidon2_ctl_lookups() {
     );
 
     // Create public inputs that will also serve as witnesses for the Poseidon2 inputs
-    let input0 = builder.add_public_input();
-    let input1 = builder.add_public_input();
+    let input0 = builder.public_input();
+    let input1 = builder.public_input();
 
     // Create a Poseidon2 operation with input CTL enabled for limbs 0 and 1
     let (_op_id, outputs) = builder
@@ -896,8 +896,8 @@ fn test_poseidon2_chained_ctl_lookups() {
     );
 
     // Create public inputs for the first operation's inputs
-    let input0 = builder.add_public_input();
-    let input1 = builder.add_public_input();
+    let input0 = builder.public_input();
+    let input1 = builder.public_input();
 
     // First Poseidon2 operation: new_start=true, inputs from witness
     let (_op_id, _outputs) = builder


### PR DESCRIPTION
## Summary

That was kind of confusing, as there is no `addition` involved, especially for methods like `add_const` / `add_public_input`.
Because of keyword hit, rename `builder.const()` as `builder.define_const()`.
