### PR TITLE
perf: leverage skipping `zeta_next` for `Const` and `Public` airs

### DIFF
--- a/circuit-prover/src/air/const_air.rs
+++ b/circuit-prover/src/air/const_air.rs
@@ -170,6 +170,14 @@ impl<F: Field, const D: usize> BaseAir<F> for ConstAir<F, D> {
             self.min_height,
         ))
     }
+
+    fn main_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
+
+    fn preprocessed_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
 }
 
 impl<AB: AirBuilder, const D: usize> Air<AB> for ConstAir<AB::F, D>

--- a/circuit-prover/src/air/public_air.rs
+++ b/circuit-prover/src/air/public_air.rs
@@ -187,6 +187,14 @@ impl<F: Field, const D: usize> BaseAir<F> for PublicAir<F, D> {
             self.min_height,
         ))
     }
+
+    fn main_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
+
+    fn preprocessed_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
 }
 
 impl<AB: AirBuilder, const D: usize> Air<AB> for PublicAir<AB::F, D>


### PR DESCRIPTION
Probably negligible savings but adding it in case. 