### PR TITLE
ci: do not leverage rustsec/audit-check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,6 +19,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1.4.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit


### PR DESCRIPTION
## Summary

`rustsec/audit-check` will be noisy as it opens issues upon warnings.
Running `cargo audit` should be enough as the job will fail.

closes #356
closes #357
closes #358