### PR TITLE
fix(circuit/lowerer): don't alias connect(value, const) into the constant's witness slot

### DIFF
--- a/circuit/src/builder/compiler/lowerer/mod.rs
+++ b/circuit/src/builder/compiler/lowerer/mod.rs
@@ -76,6 +76,12 @@ impl<'a, F: Field> ExpressionLowerer<'a, F> {
         state.emit_operations()?;
         // Verify that no registered non-primitive operation was left unreachable.
         state.validate_all_npo_emitted()?;
+        // Emit per-target equality constraints for the deferred `connect(value, const)` pairs
+        // (the `assert_zero(x)` family): these are NOT aliased into the constant's class, so the
+        // value keeps its own slot and a mismatch fails locally instead of clobbering the shared
+        // constant slot (the `WitnessId(0)` collapse). Must run AFTER `emit_operations` (every
+        // value/const target now has a witness slot) and BEFORE `backfill_connect_mappings`.
+        state.emit_deferred_const_connects()?;
         // Fill in witness mappings for connect-class members not directly visited.
         state.backfill_connect_mappings();
         // Convert the accumulated mutable state into the immutable result.

--- a/circuit/src/builder/compiler/lowerer/state.rs
+++ b/circuit/src/builder/compiler/lowerer/state.rs
@@ -50,6 +50,16 @@ pub(super) struct LoweringState<'a, F: Field> {
     /// Tracks which non-primitive operations have already been emitted,
     /// preventing duplicate emission from multiple output nodes.
     emitted_npo_ops: HashSet<NonPrimitiveOpId>,
+
+    /// `connect` pairs in which EXACTLY ONE side is a constant — normalized as
+    /// `(value_expr, const_expr)`. These are NOT fed to the DSU: aliasing a
+    /// value-bearing witness into a constant's shared slot is the unsound
+    /// representation behind the `WitnessId(0)` `assert_zero` collapse (a
+    /// genuinely-nonzero value-bearing witness gets the constant's slot and
+    /// clobbers it at witness-generation time). Instead each is lowered to a
+    /// per-target equality CONSTRAINT in [`Self::emit_deferred_const_connects`],
+    /// keeping the value in its own slot and the constant the sole writer of its.
+    deferred_const_connects: Vec<(ExprId, ExprId)>,
 }
 
 impl<'a, F: Field> LoweringState<'a, F> {
@@ -63,12 +73,43 @@ impl<'a, F: Field> LoweringState<'a, F> {
         let non_primitive_ops = lowerer.non_primitive_ops;
         let npo_registry = lowerer.npo_registry;
 
+        // Partition the declared connect pairs. A `connect(a, b)` whose two sides are BOTH
+        // value-bearing (or both constants of equal value — a no-op already skipped upstream)
+        // is a sound aliasing: both members compute the same value, so sharing one witness slot
+        // is free equality. But `connect(value, const)` (the dominant case being
+        // `assert_zero(x)` == `connect(x, ExprId::ZERO)`) is NOT sound to alias: it would give
+        // the value-bearing witness the constant's shared slot. When that value is genuinely
+        // nonzero at witness-generation time (e.g. a recursion verifier's reduced-opening
+        // accumulator that a forged/over-aligned proof leaves nonzero, OR — fatally — when
+        // many independent `assert_zero`s collapse through the single circuit-wide
+        // `ExprId::ZERO` class and one member is nonzero) its creator overwrites the constant's
+        // slot, raising `WitnessConflict { WitnessId(0) }`. We therefore DEFER each
+        // value↔const connect out of the DSU and re-emit it as a per-target equality CONSTRAINT
+        // (see `emit_deferred_const_connects`), so the value keeps its own slot, the constant
+        // stays the sole writer of its slot, and a mismatch fails LOCALLY and cleanly.
+        let mut aliasable_connects: Vec<(ExprId, ExprId)> =
+            Vec::with_capacity(lowerer.pending_connects.len());
+        let mut deferred_const_connects: Vec<(ExprId, ExprId)> = Vec::new();
+        for &(a, b) in lowerer.pending_connects.iter() {
+            let a_is_const = matches!(graph.get_expr(a), Expr::Const(_));
+            let b_is_const = matches!(graph.get_expr(b), Expr::Const(_));
+            // Exactly one side a constant ⇒ a value↔const equality: defer it.
+            if a_is_const ^ b_is_const {
+                // Normalize as (value_expr, const_expr).
+                let pair = if a_is_const { (b, a) } else { (a, b) };
+                deferred_const_connects.push(pair);
+            } else {
+                // value↔value (sound aliasing) or const↔const (equal-value no-op): keep in DSU.
+                aliasable_connects.push((a, b));
+            }
+        }
+
         Ok(Self {
             graph,
             npo_registry,
             non_primitive_ops,
-            // Build the DSU from declared connect pairs.
-            dsu: ConnectDsu::from_connects(lowerer.pending_connects),
+            // Build the DSU only from aliasable connects (value↔const pairs are deferred).
+            dsu: ConnectDsu::from_connects(&aliasable_connects),
             // Take ownership of the allocator for witness slot creation.
             witness_alloc: lowerer.witness_alloc,
             ops: Vec::new(),
@@ -80,6 +121,7 @@ impl<'a, F: Field> LoweringState<'a, F> {
             // Validate and cache the non-primitive output map (may fail).
             op_id_to_output_exprs: graph.build_npo_output_map()?,
             emitted_npo_ops: HashSet::new(),
+            deferred_const_connects,
         })
     }
 
@@ -533,6 +575,47 @@ impl<'a, F: Field> LoweringState<'a, F> {
                     });
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Emit a per-target equality CONSTRAINT for each deferred `connect(value, const)` pair.
+    ///
+    /// A `connect(x, c)` with `c` a constant (the dominant case being `assert_zero(x)` ==
+    /// `connect(x, ExprId::ZERO)`) is NOT aliased into the constant's class (that is the
+    /// unsound representation behind the circuit-wide `ExprId::ZERO` slot collapse). Instead
+    /// we enforce `x == c` as a row that keeps `x` in its OWN witness slot:
+    ///
+    /// ```text
+    ///   Op::MulAdd { a: x, b: ZERO, c: const, out: x }   // x*0 + c == x  ⇔  x == c
+    /// ```
+    ///
+    /// At witness generation `MulAdd` computes `x*0 + c = c` and writes `out == x`'s slot; if
+    /// `x` already holds a value `≠ c` the write conflicts on `x`'s OWN slot (a clean, LOCAL
+    /// failure — never the shared constant slot), and on the honest path (`x == c`) it agrees.
+    /// In the AIR this is a genuine `MulAdd` constraint binding `x` to the constant, so the
+    /// equality is enforced, not merely witness-aliased. WitnessChecks/`ext_reads` accounting
+    /// flows through the existing ALU reader/creator logic — no new bus path is needed (unlike
+    /// a second `Op::Const` writer, which `generate_preprocessed_columns` treats as a creator).
+    ///
+    /// Putting BOTH the target and the constant into the op (as `a`/`out` and `c`) keeps the
+    /// row distinct under the optimizer's ALU dedup (whose key includes these operands), so two
+    /// equalities with the same target but different constants are not collapsed.
+    pub fn emit_deferred_const_connects(&mut self) -> Result<(), CircuitBuilderError> {
+        if self.deferred_const_connects.is_empty() {
+            return Ok(());
+        }
+        let zero_widx = self.resolve_witness(ExprId::ZERO, "deferred const connect: zero const")?;
+        // Move out to satisfy the borrow checker (resolve_witness borrows &self).
+        let pairs = core::mem::take(&mut self.deferred_const_connects);
+        for &(value_expr, const_expr) in &pairs {
+            let value_widx =
+                self.resolve_witness(value_expr, "deferred const connect: value")?;
+            let const_widx =
+                self.resolve_witness(const_expr, "deferred const connect: const")?;
+            // x * 0 + c == x  ⇔  x == c, with the failure local to `value_widx`.
+            self.ops
+                .push(Op::mul_add(value_widx, zero_widx, const_widx, value_widx));
         }
         Ok(())
     }

--- a/circuit/src/builder/compiler/lowerer/tests.rs
+++ b/circuit/src/builder/compiler/lowerer/tests.rs
@@ -243,8 +243,12 @@ fn test_witness_sharing() {
     let lowerer = ExpressionLowerer::new(&graph, &[], &connects, 5, 0, alloc, &registry);
     let result = lowerer.lower().unwrap();
 
-    // 4 constants + 5 publics + 1 add = 10 operations.
-    assert_eq!(result.ops.len(), 10);
+    // 4 constants + 5 publics + 1 add + 1 deferred-const-connect equality (MulAdd) = 11 ops.
+    // The `connect(c_42, p0)` pair is a value↔const equality: it is NO LONGER aliased into the
+    // constant's slot (the unsound representation). Instead `p0` keeps its OWN witness and a
+    // `MulAdd(p0, ZERO, c_42, p0)` row binds `p0 == 42`. The value↔value chains (p1/p2/p3 and
+    // sum/p4) still alias normally.
+    assert_eq!(result.ops.len(), 11);
 
     match &result.ops[0] {
         Op::Const { out, val } => {
@@ -275,46 +279,47 @@ fn test_witness_sharing() {
         _ => panic!("Expected Const(99) at position 3"),
     }
 
-    // p0 shares witness 2 with c_42 (connect pair).
+    // p0 NO LONGER shares c_42's witness 2 — the const-connect is a deferred equality, so p0
+    // gets its OWN fresh witness (4). The `MulAdd` at the end binds it to 42.
     match &result.ops[4] {
         Op::Public { out, public_pos } => {
-            assert_eq!(out.0, 2);
+            assert_eq!(out.0, 4);
             assert_eq!(*public_pos, 0);
         }
         _ => panic!("Expected Public(0) at position 4"),
     }
-    // p1, p2, p3 all share witness 4 (transitive connect chain).
+    // p1, p2, p3 all share witness 5 (transitive value↔value connect chain).
     match &result.ops[5] {
         Op::Public { out, public_pos } => {
-            assert_eq!(out.0, 4);
+            assert_eq!(out.0, 5);
             assert_eq!(*public_pos, 1);
         }
         _ => panic!("Expected Public(1) at position 5"),
     }
     match &result.ops[6] {
         Op::Public { out, public_pos } => {
-            assert_eq!(out.0, 4);
+            assert_eq!(out.0, 5);
             assert_eq!(*public_pos, 2);
         }
         _ => panic!("Expected Public(2) at position 6"),
     }
     match &result.ops[7] {
         Op::Public { out, public_pos } => {
-            assert_eq!(out.0, 4);
+            assert_eq!(out.0, 5);
             assert_eq!(*public_pos, 3);
         }
         _ => panic!("Expected Public(3) at position 7"),
     }
-    // p4 shares witness 5 with the sum result (connect pair).
+    // p4 shares witness 6 with the sum result (value↔value connect pair).
     match &result.ops[8] {
         Op::Public { out, public_pos } => {
-            assert_eq!(out.0, 5);
+            assert_eq!(out.0, 6);
             assert_eq!(*public_pos, 4);
         }
         _ => panic!("Expected Public(4) at position 8"),
     }
 
-    // The add reads p0 (witness 2) and c_one (witness 1), writes to witness 5 (shared with p4).
+    // The add reads p0 (witness 4) and c_one (witness 1), writes to witness 6 (shared with p4).
     match &result.ops[9] {
         Op::Alu {
             kind: AluOpKind::Add,
@@ -323,47 +328,66 @@ fn test_witness_sharing() {
             out,
             ..
         } => {
-            assert_eq!(*a, WitnessId(2));
+            assert_eq!(*a, WitnessId(4));
             assert_eq!(*b, WitnessId(1));
-            assert_eq!(*out, WitnessId(5));
+            assert_eq!(*out, WitnessId(6));
         }
         _ => panic!("Expected Add at position 9"),
     }
 
-    // Verify public rows reflect the shared witnesses.
-    assert_eq!(result.public_rows.len(), 5);
-    assert_eq!(result.public_rows[0], WitnessId(2));
-    assert_eq!(result.public_rows[1], WitnessId(4));
-    assert_eq!(result.public_rows[2], WitnessId(4));
-    assert_eq!(result.public_rows[3], WitnessId(4));
-    assert_eq!(result.public_rows[4], WitnessId(5));
+    // The deferred `connect(c_42, p0)` equality: MulAdd(p0, ZERO, c_42, p0) ⇔ p0 == 42, keeping
+    // p0 in its OWN slot (4) and never aliasing it into c_42's constant slot (2).
+    match &result.ops[10] {
+        Op::Alu {
+            kind: AluOpKind::MulAdd,
+            a,
+            b,
+            c,
+            out,
+            ..
+        } => {
+            assert_eq!(*a, WitnessId(4)); // p0 (value)
+            assert_eq!(*b, WitnessId(0)); // ZERO
+            assert_eq!(*c, Some(WitnessId(2))); // c_42 (the constant)
+            assert_eq!(*out, WitnessId(4)); // out == p0's own slot
+        }
+        _ => panic!("Expected MulAdd (deferred const-connect equality) at position 10"),
+    }
 
-    // Verify the expression-to-witness map respects connect classes.
+    // Verify public rows reflect the new witnesses.
+    assert_eq!(result.public_rows.len(), 5);
+    assert_eq!(result.public_rows[0], WitnessId(4)); // p0 has its own slot now
+    assert_eq!(result.public_rows[1], WitnessId(5));
+    assert_eq!(result.public_rows[2], WitnessId(5));
+    assert_eq!(result.public_rows[3], WitnessId(5));
+    assert_eq!(result.public_rows[4], WitnessId(6));
+
+    // Verify the expression-to-witness map.
     assert_eq!(result.expr_to_widx.len(), 10);
-    // c_42 and p0 share witness 2.
+    // c_42 keeps its own constant slot (2); p0 is NOT aliased to it.
     assert_eq!(result.expr_to_widx[&c_42], WitnessId(2));
-    assert_eq!(result.expr_to_widx[&p0], WitnessId(2));
-    // p1, p2, p3 share witness 4.
-    assert_eq!(result.expr_to_widx[&p1], WitnessId(4));
-    assert_eq!(result.expr_to_widx[&p2], WitnessId(4));
-    assert_eq!(result.expr_to_widx[&p3], WitnessId(4));
-    // sum and p4 share witness 5.
-    assert_eq!(result.expr_to_widx[&sum], WitnessId(5));
-    assert_eq!(result.expr_to_widx[&p4], WitnessId(5));
+    assert_eq!(result.expr_to_widx[&p0], WitnessId(4));
+    // p1, p2, p3 share witness 5.
+    assert_eq!(result.expr_to_widx[&p1], WitnessId(5));
+    assert_eq!(result.expr_to_widx[&p2], WitnessId(5));
+    assert_eq!(result.expr_to_widx[&p3], WitnessId(5));
+    // sum and p4 share witness 6.
+    assert_eq!(result.expr_to_widx[&sum], WitnessId(6));
+    assert_eq!(result.expr_to_widx[&p4], WitnessId(6));
     // Unconnected constants each have their own witness.
     assert_eq!(result.expr_to_widx[&c_zero], WitnessId(0));
     assert_eq!(result.expr_to_widx[&c_one], WitnessId(1));
     assert_eq!(result.expr_to_widx[&c_99], WitnessId(3));
 
     assert_eq!(result.public_mappings.len(), 5);
-    assert_eq!(result.public_mappings[&p0], WitnessId(2));
-    assert_eq!(result.public_mappings[&p1], WitnessId(4));
-    assert_eq!(result.public_mappings[&p2], WitnessId(4));
-    assert_eq!(result.public_mappings[&p3], WitnessId(4));
-    assert_eq!(result.public_mappings[&p4], WitnessId(5));
+    assert_eq!(result.public_mappings[&p0], WitnessId(4));
+    assert_eq!(result.public_mappings[&p1], WitnessId(5));
+    assert_eq!(result.public_mappings[&p2], WitnessId(5));
+    assert_eq!(result.public_mappings[&p3], WitnessId(5));
+    assert_eq!(result.public_mappings[&p4], WitnessId(6));
 
-    // Only 6 unique witnesses: 0 (zero), 1 (one), 2 (42/p0), 3 (99), 4 (p1/p2/p3), 5 (sum/p4).
-    assert_eq!(result.witness_count, 6);
+    // 7 unique witnesses now: 0 (zero), 1 (one), 2 (42), 3 (99), 4 (p0), 5 (p1/p2/p3), 6 (sum/p4).
+    assert_eq!(result.witness_count, 7);
 }
 
 #[test]
@@ -552,22 +576,33 @@ fn test_horner_acc_lowering() {
 
 #[test]
 fn test_backfill_connect_unvisited_member() {
-    // Verify that connect-class members all share the same witness,
-    // even if some members would not be directly visited during lowering.
-    // The backfill pass is a safety net for this invariant.
+    // Verify that VALUE↔VALUE connect-class members all share the same witness, even if some
+    // members would not be directly visited during lowering (the backfill pass is the safety
+    // net). A VALUE↔CONST connect is NOT aliased: the const keeps its own slot and a deferred
+    // equality constraint binds the value to it.
     let mut graph = create_graph_with_zero();
     let c1 = graph.add_expr(Expr::Const(BabyBear::ONE));
     let p0 = graph.add_expr(Expr::Public(0));
     let p1 = graph.add_expr(Expr::Public(1));
-    // Connect c1, p0, and p1 into a single equivalence class.
+    // (c1, p0) is a value↔const equality (deferred); (p0, p1) is value↔value (aliased).
     let connects = vec![(c1, p0), (p0, p1)];
     let alloc = WitnessAllocator::new();
     let registry = HashMap::new();
     let lowerer = ExpressionLowerer::new(&graph, &[], &connects, 2, 0, alloc, &registry);
     let result = lowerer.lower().unwrap();
 
-    // All three should share the same witness (c1 binds the class in Phase A).
-    let w = result.expr_to_widx[&c1];
-    assert_eq!(result.expr_to_widx[&p0], w);
+    // p0 and p1 (value↔value) share one witness.
+    let w = result.expr_to_widx[&p0];
     assert_eq!(result.expr_to_widx[&p1], w);
+    // c1 (the constant) keeps its OWN slot — NOT aliased into the p0/p1 class.
+    assert_ne!(result.expr_to_widx[&c1], w);
+    // The deferred const-connect equality (MulAdd binding p0 == c1) was emitted.
+    let has_eq = result.ops.iter().any(|op| {
+        matches!(
+            op,
+            Op::Alu { kind: AluOpKind::MulAdd, c: Some(cw), out, .. }
+                if *out == w && *cw == result.expr_to_widx[&c1]
+        )
+    });
+    assert!(has_eq, "expected a deferred const-connect MulAdd binding p0 == c1");
 }

--- a/circuit/src/tables/runner.rs
+++ b/circuit/src/tables/runner.rs
@@ -695,12 +695,26 @@ mod tests {
 
         let f = BabyBear::from_u64;
         let neg_111 = -f(111);
+        // `assert_zero(sub_result)` lowers to `connect(sub_result, ZERO)`, a value-vs-constant
+        // pair. It is NOT aliased into the constant's class: `sub_result` keeps its own witness
+        // slot (W5, holding 0) and an explicit equality `MulAdd(sub_result, ZERO, ZERO, sub_result)`
+        // binds it to zero. (Previously `sub_result` was aliased onto the shared `ZERO` slot, which
+        // collapses every `assert_zero` in a circuit into one slot and can raise a spurious
+        // `WitnessConflict { WitnessId(0) }`.) The `-111` constant therefore lands at W6.
         assert_eq!(
             traces,
             Traces {
-                witness_trace: WitnessTrace::new(vec![f(0), f(37), f(111), f(3), f(111), neg_111]),
+                witness_trace: WitnessTrace::new(vec![
+                    f(0),
+                    f(37),
+                    f(111),
+                    f(3),
+                    f(111),
+                    f(0),
+                    neg_111
+                ]),
                 const_trace: ConstTrace {
-                    index: vec![WitnessId(0), WitnessId(1), WitnessId(2), WitnessId(5)],
+                    index: vec![WitnessId(0), WitnessId(1), WitnessId(2), WitnessId(6)],
                     values: vec![f(0), f(37), f(111), neg_111],
                 },
                 public_trace: PublicTrace {
@@ -708,11 +722,16 @@ mod tests {
                     values: vec![],
                 },
                 alu_trace: AluTrace {
-                    op_kind: vec![AluOpKind::Mul, AluOpKind::Add],
-                    values: vec![[f(37), f(3), f(0), f(111)], [f(111), neg_111, f(0), f(0)]],
+                    op_kind: vec![AluOpKind::Mul, AluOpKind::Add, AluOpKind::MulAdd],
+                    values: vec![
+                        [f(37), f(3), f(0), f(111)],
+                        [f(111), neg_111, f(0), f(0)],
+                        [f(0), f(0), f(0), f(0)],
+                    ],
                     indices: vec![
                         [WitnessId(1), WitnessId(3), WitnessId(0), WitnessId(4)],
-                        [WitnessId(4), WitnessId(5), WitnessId(0), WitnessId(0)],
+                        [WitnessId(4), WitnessId(6), WitnessId(0), WitnessId(5)],
+                        [WitnessId(5), WitnessId(0), WitnessId(0), WitnessId(5)],
                     ],
                 },
                 non_primitive_traces: HashMap::new(),


### PR DESCRIPTION
## What this fixes

In the circuit lowerer, declared `connect(a, b)` pairs are unioned in a DSU
(`ConnectDsu`) so that connected expressions share a single witness slot. That
aliasing is sound when both sides are value-bearing — they compute the same
value, so sharing a slot is free equality. It is **not** sound when exactly one
side is a constant. The dominant case is `assert_zero(x)`, which lowers to
`connect(x, ExprId::ZERO)`.

Aliasing `x` into the constant's class gives the value-bearing witness the
*constant's* shared slot. Because every `assert_zero` in a circuit routes through
the single circuit-wide `ExprId::ZERO` class, many independent `assert_zero`s
collapse into one shared slot. If any member is genuinely nonzero at
witness-generation time, its creator overwrites the shared constant slot and the
prover raises `WitnessConflict { WitnessId(0) }` — a spurious, hard-to-localize
failure rather than a clean, local mismatch. (We hit this as a ~219-member
`ZERO`-class collapse in a larger recursive circuit.)

## The fix

`connect` pairs with **exactly one** constant side are no longer fed to the DSU.
They are deferred and, after `emit_operations`, re-emitted as a per-target
equality constraint:

```text
Op::MulAdd { a: x, b: ZERO, c: const, out: x }   // x*0 + c == x  ⇔  x == c
```

This keeps `x` in its own witness slot, keeps the constant the sole writer of its
slot, and makes a mismatch fail locally on `x`'s slot. We chose `MulAdd` over a
second `Op::Const` because `ConstAir` treats every `Op::Const` as a slot creator
(which would reintroduce a double-creator), whereas `MulAdd` flows through the
existing ALU bus accounting with no new bus path. The equality is a genuine AIR
constraint, so it is *enforced*, not merely witness-aliased.

## Scope

Four files:

- `circuit/src/builder/compiler/lowerer/state.rs` — partition declared connects,
  defer value↔const pairs, add `emit_deferred_const_connects`.
- `circuit/src/builder/compiler/lowerer/mod.rs` — invoke it after
  `emit_operations`, before `backfill_connect_mappings`.
- `circuit/src/builder/compiler/lowerer/tests.rs` and
  `circuit/src/tables/runner.rs` — expected-output tests updated to the equality
  semantics (an `assert_zero` now produces one extra `MulAdd` equality row and
  keeps its target in its own slot).

## Testing

- `cargo test -p p3-circuit` — **323 passed, 0 failed**, off current `main`
  (`b81dc0d`) plus this commit.

## Honest framing (please read)

This was developed with substantial AI assistance. It passes the `p3-circuit`
suite but has **not** been independently audited by a STARK/recursion expert, and
it touches soundness-relevant accounting (witness-slot creation). We believe it
is correct and our tests agree, but please treat it as an unaudited proposal and
**review carefully**. If the framing is wrong or it isn't useful, just close — no
hard feelings.

We deliberately kept this small and easy to evaluate.

## Related work we'd be happy to upstream separately

While building an IVC light client on top of `Plonky3-recursion`, we also built a
couple of more general pieces on our fork that upstream currently lacks:

- A **verified public-output channel** for recursive proofs
  (`expose_as_public_output`): a bus-reader AIR that binds arbitrary in-circuit
  witnesses to host-readable public outputs of a recursive proof, provably equal
  to the genuine verified witnesses (so a light client can read accumulator
  state / chain heads / roots out of an aggregate proof).
- An **in-circuit verifier-key identity pin** for IVC fixed-points
  (`pin_preprocessed_commit`): constrains a child proof's preprocessed
  commitment to expected constants, so a from-scratch prover can't fold a proof
  of a *different* circuit — the stable anchor that makes "one running circuit
  verifies its own previous proof" close into a genuine fixed point.

Both are more general than our application, but they're larger and also touch
soundness, so we left them out of this PR to keep it focused. If either is of
interest we're glad to prepare separate PRs (with the same "unaudited, please
review" framing). No expectation either way.
