### PR TITLE
feat(circuit): expose_as_public_output — a verified public-output channel for recursive proofs

### DIFF
--- a/circuit-prover/src/air/expose_claim_air.rs
+++ b/circuit-prover/src/air/expose_claim_air.rs
@@ -1,0 +1,210 @@
+//! [`ExposeClaimAir`] surfaces N chosen witness values as table public values,
+//! BOUND to the genuine witnesses via the `WitnessChecks` bus.
+//!
+//! This is a verified public-output channel for a recursive circuit: given any
+//! set of in-circuit witnesses (each one SENT on the `WitnessChecks` bus by the
+//! table that created it — a primitive `PublicAir`, an ALU output, a Poseidon2
+//! limb, etc.), this table READS each of them back (reader multiplicity `-1`)
+//! into a main column and constrains the table's public value for that lane to
+//! equal the value it read. Because the read is bus-bound to the genuine witness,
+//! and the public value is locally constrained to the read, the host-readable
+//! `non_primitives[].public_values` are provably the genuine in-circuit values —
+//! not free prover-chosen scalars.
+//!
+//! A common use is to surface an aggregate's running state (a chain head, a
+//! Merkle root, a step counter, a running hash) out of a fold so a light client
+//! can read it; but the channel is generic over which witnesses are exposed.
+//!
+//! # Column layout (per lane = per exposed value)
+//!
+//! **Main columns** (D per lane): `v_0, ..., v_{D-1}` — the value read off the bus.
+//!
+//! **Preprocessed columns** per lane: `witness_idx`, `read_mult` (2 columns).
+//!
+//! **Public values**: one base-field public value per lane, in lane order.
+//!
+//! # Constraints (per lane)
+//!
+//! - Receive the FULL `[witness_idx, v_0, ..., v_{D-1}]` ext tuple on `WitnessChecks`
+//!   with multiplicity `read_mult` — bus-bound to the genuine witness the creating
+//!   table sent, so `v_1..v_{D-1}` cannot be freely chosen by the prover.
+//! - `public_value[lane] == v_0` (coeff-0 of the read cell is the host-readable claim),
+//!   gated by the active-lane selector so padding rows do not force it to zero.
+//! - The higher coeffs `v_1..v_{D-1}` are NOT constrained to zero: a witness may pack
+//!   genuinely-nonzero base lanes into one ext element (e.g. a Poseidon2 output limb),
+//!   so forcing them to zero would receive a different tuple than was sent and unbalance
+//!   the global bus. Their soundness comes from the bus binding, not a local zero check.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_field::{Field, PrimeCharacteristicRing};
+use p3_lookup::{Count, InteractionBuilder};
+use p3_matrix::dense::RowMajorMatrix;
+use tracing::instrument;
+
+use super::expose_claim_columns::{EXPOSE_CLAIM_PREP_LANE_COL_MAP, EXPOSE_CLAIM_PREP_LANE_WIDTH};
+
+/// AIR for the exposed-claim table.
+///
+/// All lanes pack into a single row (the table has exactly `num_claims` lanes
+/// and one logical row), so the public values line up with the lanes directly.
+#[derive(Debug, Clone)]
+pub struct ExposeClaimAir<F, const D: usize> {
+    /// Number of claim values (= lanes = number of public values).
+    pub(crate) num_claims: usize,
+    pub(crate) preprocessed: Vec<F>,
+    pub(crate) min_height: usize,
+    _phantom: PhantomData<F>,
+}
+
+impl<F: Field + PrimeCharacteristicRing, const D: usize> ExposeClaimAir<F, D> {
+    /// Main trace width per lane: D columns (the read value).
+    pub const fn lane_width() -> usize {
+        D
+    }
+
+    /// Preprocessed width per lane: `[witness_idx, read_mult]`.
+    pub const fn preprocessed_lane_width() -> usize {
+        EXPOSE_CLAIM_PREP_LANE_WIDTH
+    }
+
+    /// Create a new `ExposeClaimAir` with the given preprocessed data.
+    pub fn new_with_preprocessed(
+        num_claims: usize,
+        preprocessed: Vec<F>,
+        min_height: usize,
+    ) -> Self {
+        Self {
+            num_claims: num_claims.max(1),
+            preprocessed,
+            min_height,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Build the single-row main trace matrix from the exposed-claim rows, padded to the SAME
+    /// `min_height` the preprocessed trace ([`Self::preprocessed_trace`]) and the reported table
+    /// degree use — matching the convention of the sibling single-row tables (`ConstAir`,
+    /// `PublicAir`, `RecomposeAir`), which all take a `min_height` and pad to it. (The batch prover
+    /// re-pads non-primitive traces to `min_height` downstream regardless, so this is a defensive
+    /// consistency fix at the source rather than a behavioural change to the committed proof.)
+    #[instrument(skip_all, name = "ExposeClaimAir::build_trace")]
+    pub fn trace_to_matrix(
+        rows: &[p3_circuit::ops::expose_claim::ExposeClaimCircuitRow<F>],
+        min_height: usize,
+    ) -> RowMajorMatrix<F> {
+        let lane_w = Self::lane_width();
+        let num_claims = rows.len().max(1);
+        let row_width = num_claims * lane_w;
+
+        let mut values = F::zero_vec(row_width);
+        for (lane, row) in rows.iter().enumerate() {
+            // Reproduce the FULL witness value (all `D` coefficients), so the
+            // `WitnessChecks` receive tuple matches the tuple the creator sent. A
+            // base-field witness contributes `(value, 0, ..., 0)`; a Poseidon2 output
+            // limb contributes its 4 genuinely-nonzero base lanes. (`read_coeffs` is
+            // populated by the trace generator; empty only on degenerate rows, where
+            // we fall back to the coeff-0 embedding.)
+            if row.read_coeffs.is_empty() {
+                values[lane * lane_w] = row.value;
+            } else {
+                for (j, &c) in row.read_coeffs.iter().take(lane_w).enumerate() {
+                    values[lane * lane_w + j] = c;
+                }
+            }
+        }
+
+        let mut mat = RowMajorMatrix::new(values, row_width);
+        // Pad to `min_height` (power-of-two), matching `preprocessed_trace` + the reported degree.
+        mat.pad_to_min_power_of_two_height(min_height, F::ZERO);
+        mat
+    }
+}
+
+impl<F: Field, const D: usize> BaseAir<F> for ExposeClaimAir<F, D> {
+    fn width(&self) -> usize {
+        self.num_claims * D
+    }
+
+    fn num_public_values(&self) -> usize {
+        self.num_claims
+    }
+
+    fn preprocessed_width(&self) -> usize {
+        self.num_claims * Self::preprocessed_lane_width()
+    }
+
+    fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+        let width = self.num_claims * Self::preprocessed_lane_width();
+        let mut mat = RowMajorMatrix::from_flat_padded(self.preprocessed.to_vec(), width, F::ZERO);
+        mat.pad_to_min_power_of_two_height(self.min_height, F::ZERO);
+        Some(mat)
+    }
+
+    fn main_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
+
+    fn preprocessed_next_row_columns(&self) -> Vec<usize> {
+        vec![]
+    }
+}
+
+impl<AB: AirBuilder + InteractionBuilder, const D: usize> Air<AB> for ExposeClaimAir<AB::F, D>
+where
+    AB::F: Field,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let main_local = main.current_slice();
+        let prep = builder.preprocessed().clone();
+        let prep_local = prep.current_slice();
+        let pis = builder.public_values().to_vec();
+
+        let lane_w = Self::lane_width();
+        let prep_lane_w = Self::preprocessed_lane_width();
+
+        for lane in 0..self.num_claims {
+            let main_off = lane * lane_w;
+            let prep_off = lane * prep_lane_w;
+
+            let witness_idx: AB::Expr =
+                prep_local[prep_off + EXPOSE_CLAIM_PREP_LANE_COL_MAP.witness_idx].into();
+            let read_mult: AB::Expr =
+                prep_local[prep_off + EXPOSE_CLAIM_PREP_LANE_COL_MAP.read_mult].into();
+
+            // Receive the witness cell off the WitnessChecks bus. The reader
+            // multiplicity (`-1` per active lane) is matched by the writer
+            // `PublicAir` send, keeping the bus balanced.
+            let mut values: Vec<AB::Expr> = Vec::with_capacity(1 + D);
+            values.push(witness_idx);
+            for j in 0..D {
+                values.push(main_local[main_off + j].into());
+            }
+            builder.push_interaction("WitnessChecks", values, Count::bounded(read_mult.clone(), 1));
+
+            // Active-lane selector: `-read_mult` is `1` on a real lane (read_mult
+            // == -1) and `0` on a padding row (read_mult == 0). All local
+            // constraints below are GATED by it so padding rows (which carry zero
+            // main columns) do not force the nonzero public value to zero.
+            let active: AB::Expr = AB::Expr::ZERO - read_mult;
+
+            // Bind the table's host-exposed public value to coeff-0 of the value
+            // read off the bus: `active * (public_value[lane] - v_0) == 0`.
+            //
+            // The higher coefficients `v_1..v_{D-1}` are NOT constrained to zero: the
+            // read cell carries the FULL witness value so its `WitnessChecks` receive
+            // tuple matches the tuple the creating table sent (a Poseidon2 output limb
+            // packs 4 genuinely-nonzero base lanes into one ext element; forcing them
+            // to zero here would receive a different tuple than was sent, unbalancing
+            // the global bus). Only coeff-0 is exposed as the host-readable claim, and
+            // it is bus-bound to the genuine witness — which is the soundness property.
+            let pv: AB::Expr = pis[lane].into();
+            let v0: AB::Expr = main_local[main_off].into();
+            builder.assert_zero(active.clone() * (pv - v0));
+        }
+    }
+}

--- a/circuit-prover/src/air/expose_claim_columns.rs
+++ b/circuit-prover/src/air/expose_claim_columns.rs
@@ -1,0 +1,37 @@
+//! Column layout for [`super::expose_claim_air::ExposeClaimAir`] preprocessed traces.
+//!
+//! One lane per exposed claim value. Each lane carries the witness index whose
+//! value is read off the `WitnessChecks` bus (reader multiplicity `-1`) and
+//! surfaced as a table public value.
+
+use core::mem::{size_of, transmute};
+
+use super::column_layout::column_indices;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ExposeClaimPrepLaneCols<T: Copy> {
+    /// D-scaled base-field index of the witness whose value this lane reads.
+    pub witness_idx: T,
+    /// Reader multiplicity for the `WitnessChecks` receive (always `-1` for an
+    /// active lane, `0` for padding).
+    pub read_mult: T,
+}
+
+pub(crate) const EXPOSE_CLAIM_PREP_LANE_WIDTH: usize =
+    size_of::<ExposeClaimPrepLaneCols<u8>>();
+
+const fn expose_claim_prep_lane_col_map() -> ExposeClaimPrepLaneCols<usize> {
+    let indices = column_indices::<EXPOSE_CLAIM_PREP_LANE_WIDTH>();
+    unsafe {
+        transmute::<[usize; EXPOSE_CLAIM_PREP_LANE_WIDTH], ExposeClaimPrepLaneCols<usize>>(indices)
+    }
+}
+
+pub(crate) const EXPOSE_CLAIM_PREP_LANE_COL_MAP: ExposeClaimPrepLaneCols<usize> =
+    expose_claim_prep_lane_col_map();
+
+const _: () = assert!(
+    size_of::<ExposeClaimPrepLaneCols<usize>>()
+        == EXPOSE_CLAIM_PREP_LANE_WIDTH * size_of::<usize>()
+);

--- a/circuit-prover/src/air/mod.rs
+++ b/circuit-prover/src/air/mod.rs
@@ -2,6 +2,8 @@ pub mod alu_air;
 mod alu_columns;
 mod column_layout;
 pub mod const_air;
+pub mod expose_claim_air;
+mod expose_claim_columns;
 pub mod public_air;
 pub mod recompose_air;
 mod recompose_columns;
@@ -13,5 +15,6 @@ pub mod test_utils;
 
 pub use alu_air::{AluAir, AluExtMulKind};
 pub use const_air::ConstAir;
+pub use expose_claim_air::ExposeClaimAir;
 pub use public_air::{PublicAir, WitnessSendAir};
 pub use recompose_air::RecomposeAir;

--- a/circuit-prover/src/batch_stark_prover.rs
+++ b/circuit-prover/src/batch_stark_prover.rs
@@ -52,6 +52,7 @@ use crate::constraint_profile::ConstraintProfile;
 use crate::field_params::ExtractBinomialW;
 
 mod dynamic_air;
+mod expose_claim;
 mod packing;
 mod poseidon1;
 mod poseidon2;
@@ -69,6 +70,7 @@ pub use poseidon2::{
     Poseidon2AirBuilder, Poseidon2AirWrapperInner, Poseidon2Preprocessor, Poseidon2Prover,
     Poseidon2ProverD2, poseidon2_preprocessor, poseidon2_verifier_air_from_config,
 };
+pub use expose_claim::{ExposeClaimAirBuilder, ExposeClaimPreprocessor, ExposeClaimProver};
 pub use recompose::{RecomposeAirBuilder, RecomposePreprocessor, RecomposeProver};
 
 /// Prime modulus of the BabyBear field (`2^31 - 2^27 + 1`).
@@ -772,6 +774,17 @@ where
         }
     }
 
+    fn num_public_values(&self) -> usize {
+        match self {
+            Self::Const(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Public(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Alu(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Dynamic(a) => {
+                <dyn CloneableBatchAir<SC> as BaseAir<Val<SC>>>::num_public_values(a.air())
+            }
+        }
+    }
+
     fn preprocessed_width(&self) -> usize {
         match self {
             Self::Const(a) => BaseAir::<Val<SC>>::preprocessed_width(a),
@@ -1123,6 +1136,21 @@ where
     {
         self.register_recompose_table::<D>(split_coeff_tables);
         self
+    }
+
+    /// Register the expose-claim table prover (the host-readable, bus-bound
+    /// public-value channel). The verifier needs it to interpret an
+    /// `expose_claim` non-primitive op in a proof.
+    pub fn register_expose_claim_table<const D: usize>(&mut self)
+    where
+        SC: Send + Sync,
+        Val<SC>: StarkField,
+        SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+            Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+    {
+        for prover in expose_claim_table_provers::<SC, D>() {
+            self.register_table_prover(prover);
+        }
     }
 
     /// Return the current [`TablePacking`] configuration.
@@ -1869,6 +1897,37 @@ where
     } else {
         vec![Box::new(RecomposeAirBuilder::<D>::new(lanes, false))]
     }
+}
+
+/// Expose-claim preprocessor for a given field.
+pub fn expose_claim_preprocessor<F>() -> Box<dyn NpoPreprocessor<F>>
+where
+    F: StarkField + PrimeField,
+    ExposeClaimPreprocessor: NpoPreprocessor<F>,
+{
+    Box::new(ExposeClaimPreprocessor::new())
+}
+
+/// Expose-claim table prover for a given extension field degree.
+pub fn expose_claim_table_provers<SC, const D: usize>() -> Vec<Box<dyn TableProver<SC>>>
+where
+    SC: StarkGenericConfig + 'static + Send + Sync,
+    Val<SC>: StarkField,
+    SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+        Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+{
+    vec![Box::new(ExposeClaimProver::<D>::new())]
+}
+
+/// Expose-claim AIR builder for a given extension field degree.
+pub fn expose_claim_air_builders<SC, const D: usize>() -> Vec<Box<dyn NpoAirBuilder<SC, D>>>
+where
+    SC: StarkGenericConfig + 'static + Send + Sync,
+    Val<SC>: StarkField,
+    SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+        Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+{
+    vec![Box::new(ExposeClaimAirBuilder::<D>::new())]
 }
 
 #[cfg(test)]

--- a/circuit-prover/src/batch_stark_prover/expose_claim.rs
+++ b/circuit-prover/src/batch_stark_prover/expose_claim.rs
@@ -1,0 +1,293 @@
+//! Expose-claim table prover: builds `ExposeClaimAir` instances for the batch
+//! STARK prover and POPULATES `public_values` with the bus-bound claim values.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use hashbrown::HashMap;
+use p3_baby_bear::BabyBear;
+use p3_batch_stark::{StarkGenericConfig, Val};
+use p3_circuit::ops::expose_claim::ExposeClaimTrace;
+use p3_circuit::ops::{NonPrimitivePreprocessedMap, NpoTypeId};
+use p3_circuit::tables::Traces;
+use p3_circuit::{CircuitError, PreprocessedColumns};
+use p3_field::extension::{BinomialExtensionField, QuinticTrinomialExtensionField};
+use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing, PrimeField64};
+use p3_goldilocks::Goldilocks;
+use p3_koala_bear::KoalaBear;
+use p3_uni_stark::{SymbolicExpression, SymbolicExpressionExt};
+use p3_util::log2_ceil_usize;
+
+use super::dynamic_air::{
+    BatchAir, BatchTableInstance, DynamicAirEntry, TableProver, transmute_traces,
+};
+use super::{NonPrimitiveTableEntry, TablePacking};
+use crate::air::ExposeClaimAir;
+use crate::common::{CircuitTableAir, NpoAirBuilder, NpoPreprocessor};
+use crate::config::StarkField;
+use crate::{ConstraintProfile, impl_table_prover_batch_instances_from_base};
+
+/// Preprocessed lane width (base): `[witness_idx, read_mult]`.
+const EXPOSE_CLAIM_PREP_LANE_WIDTH: usize = 2;
+
+impl<SC, const D: usize> BatchAir<SC> for ExposeClaimAir<Val<SC>, D>
+where
+    SC: StarkGenericConfig + Send + Sync,
+    Val<SC>: StarkField,
+    SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+        Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+{
+}
+
+/// Table prover for the expose-claim NPO.
+pub struct ExposeClaimProver<const D: usize>;
+
+impl<const D: usize> ExposeClaimProver<D> {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    fn batch_instance_base<SC>(
+        &self,
+        _config: &SC,
+        packing: &TablePacking,
+        traces: &Traces<Val<SC>>,
+    ) -> Option<BatchTableInstance<SC>>
+    where
+        SC: StarkGenericConfig + 'static + Send + Sync,
+        Val<SC>: StarkField,
+        SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+            Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+    {
+        let op_type = NpoTypeId::expose_claim();
+        let trace = traces.non_primitive_traces.get(&op_type)?;
+        if trace.rows() == 0 {
+            return None;
+        }
+        let t = trace
+            .as_any()
+            .downcast_ref::<ExposeClaimTrace<Val<SC>>>()?;
+
+        let num_claims = t.total_rows();
+        let min_height = packing.min_trace_height();
+
+        // Preprocessed (base): [witness_idx, read_mult=-1] per lane.
+        let neg_one = Val::<SC>::ZERO - Val::<SC>::ONE;
+        let mut preprocessed = Val::<SC>::zero_vec(num_claims * EXPOSE_CLAIM_PREP_LANE_WIDTH);
+        for (i, row) in t.operations.iter().enumerate() {
+            let base = i * EXPOSE_CLAIM_PREP_LANE_WIDTH;
+            preprocessed[base] = row.witness_id.base_field_index::<Val<SC>, D>();
+            preprocessed[base + 1] = neg_one;
+        }
+
+        // Public values: the claim values, in lane order. THIS is the host-readable
+        // channel, bound to the bus-read value by the AIR.
+        let public_values: Vec<Val<SC>> = t.operations.iter().map(|row| row.value).collect();
+
+        let air = ExposeClaimAir::<Val<SC>, D>::new_with_preprocessed(
+            num_claims,
+            preprocessed,
+            min_height,
+        );
+        let matrix = ExposeClaimAir::<Val<SC>, D>::trace_to_matrix(&t.operations, min_height);
+
+        Some(BatchTableInstance {
+            op_type,
+            air: DynamicAirEntry::new(Box::new(air)),
+            trace: matrix,
+            public_values,
+            rows: num_claims,
+            lanes: num_claims,
+        })
+    }
+}
+
+impl<const D: usize> Default for ExposeClaimProver<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SC, const D: usize> TableProver<SC> for ExposeClaimProver<D>
+where
+    SC: StarkGenericConfig + 'static + Send + Sync,
+    Val<SC>: StarkField,
+    SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+        Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+{
+    fn op_type(&self) -> NpoTypeId {
+        NpoTypeId::expose_claim()
+    }
+
+    fn lanes(&self) -> usize {
+        1
+    }
+
+    impl_table_prover_batch_instances_from_base!(batch_instance_base);
+
+    fn batch_air_from_table_entry(
+        &self,
+        _config: &SC,
+        _degree: usize,
+        _circuit_extension_degree: u32,
+        table_entry: &NonPrimitiveTableEntry<SC>,
+    ) -> Result<DynamicAirEntry<SC>, String> {
+        // `rows` == number of claims (one lane per claim, one logical row).
+        let air = ExposeClaimAir::<Val<SC>, D>::new_with_preprocessed(table_entry.rows, Vec::new(), 1);
+        Ok(DynamicAirEntry::new(Box::new(air)))
+    }
+
+    fn air_with_committed_preprocessed(
+        &self,
+        committed_prep: Vec<Val<SC>>,
+        min_height: usize,
+        _lanes: usize,
+        _circuit_extension_degree: u32,
+    ) -> Option<DynamicAirEntry<SC>> {
+        let num_claims = committed_prep.len() / EXPOSE_CLAIM_PREP_LANE_WIDTH;
+        let air = ExposeClaimAir::<Val<SC>, D>::new_with_preprocessed(
+            num_claims,
+            committed_prep,
+            min_height,
+        );
+        Some(DynamicAirEntry::new(Box::new(air)))
+    }
+}
+
+// ============================================================================
+// Preprocessor
+// ============================================================================
+
+/// NpoPreprocessor for the expose-claim table.
+///
+/// Converts the EF-registered `[witness_idx, mult_placeholder]` lane rows to
+/// base, overwriting the placeholder with the reader multiplicity `-1`.
+#[derive(Default, Clone)]
+pub struct ExposeClaimPreprocessor;
+
+impl ExposeClaimPreprocessor {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+macro_rules! impl_expose_claim_preprocessor {
+    ($field:ty, $( ($ef:ty, $d:literal) ),+ $(,)?) => {
+        impl NpoPreprocessor<$field> for ExposeClaimPreprocessor {
+            fn preprocess(
+                &self,
+                _circuit: &dyn core::any::Any,
+                preprocessed: &mut dyn core::any::Any,
+            ) -> Result<NonPrimitivePreprocessedMap<$field>, CircuitError> {
+                type F = $field;
+                $(
+                    if let Some(prep) =
+                        preprocessed.downcast_mut::<PreprocessedColumns<$ef, $d>>()
+                    {
+                        return expose_claim_preprocess_impl::<F, _, $d>(prep);
+                    }
+                )+
+                if let Some(prep) = preprocessed.downcast_mut::<PreprocessedColumns<F, 1>>() {
+                    return expose_claim_preprocess_impl::<F, _, 1>(prep);
+                }
+                Ok(HashMap::new())
+            }
+        }
+    };
+}
+
+impl_expose_claim_preprocessor!(KoalaBear, (BinomialExtensionField<KoalaBear, 4>, 4), (QuinticTrinomialExtensionField<KoalaBear>, 5));
+impl_expose_claim_preprocessor!(BabyBear, (BinomialExtensionField<BabyBear, 4>, 4));
+impl_expose_claim_preprocessor!(Goldilocks, (BinomialExtensionField<Goldilocks, 2>, 2));
+
+fn expose_claim_preprocess_impl<F, EF, const D: usize>(
+    prep: &PreprocessedColumns<EF, D>,
+) -> Result<NonPrimitivePreprocessedMap<F>, CircuitError>
+where
+    F: StarkField + PrimeField64,
+    EF: Field + ExtensionField<F> + 'static,
+{
+    let op_type = NpoTypeId::expose_claim();
+    let ef_data = match prep.non_primitive.get(&op_type) {
+        Some(d) if !d.is_empty() => d,
+        _ => return Ok(HashMap::new()),
+    };
+
+    let prep_width = EXPOSE_CLAIM_PREP_LANE_WIDTH;
+
+    let mut prep_base: Vec<F> = ef_data
+        .iter()
+        .map(|v| v.as_base().ok_or(CircuitError::InvalidPreprocessedValues))
+        .collect::<Result<Vec<_>, CircuitError>>()?;
+
+    if !prep_base.len().is_multiple_of(prep_width) {
+        return Err(CircuitError::InvalidPreprocessedValues);
+    }
+
+    let neg_one = F::ZERO - F::ONE;
+    let num_rows = prep_base.len() / prep_width;
+    for row_idx in 0..num_rows {
+        // Slot 0 = witness index (left as-is); slot 1 = reader multiplicity.
+        prep_base[row_idx * prep_width + 1] = neg_one;
+    }
+
+    let mut result = HashMap::new();
+    result.insert(op_type, prep_base);
+    Ok(result)
+}
+
+// ============================================================================
+// AIR Builder
+// ============================================================================
+
+/// NpoAirBuilder for the expose-claim table.
+#[derive(Clone, Default)]
+pub struct ExposeClaimAirBuilder<const D: usize>;
+
+impl<const D: usize> ExposeClaimAirBuilder<D> {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl<SC, const D: usize> NpoAirBuilder<SC, D> for ExposeClaimAirBuilder<D>
+where
+    SC: StarkGenericConfig + 'static + Send + Sync,
+    Val<SC>: StarkField,
+    SymbolicExpressionExt<Val<SC>, SC::Challenge>:
+        Algebra<SymbolicExpression<Val<SC>>> + Algebra<SC::Challenge>,
+{
+    fn lanes(&self) -> usize {
+        1
+    }
+
+    fn try_build(
+        &self,
+        op_type: &NpoTypeId,
+        prep_base: &[Val<SC>],
+        min_height: usize,
+        _lanes: usize,
+        _constraint_profile: ConstraintProfile,
+    ) -> Option<(CircuitTableAir<SC, D>, usize)> {
+        if op_type.as_str() != "expose_claim" {
+            return None;
+        }
+
+        let num_claims = (prep_base.len() / EXPOSE_CLAIM_PREP_LANE_WIDTH).max(1);
+        let air = ExposeClaimAir::<Val<SC>, D>::new_with_preprocessed(
+            num_claims,
+            prep_base.to_vec(),
+            min_height,
+        );
+
+        // The table has exactly one logical (power-of-two-padded) row.
+        let padded_rows = 1usize.max(min_height.next_power_of_two());
+        let degree = log2_ceil_usize(padded_rows);
+
+        Some((
+            CircuitTableAir::Dynamic(DynamicAirEntry::new(Box::new(air))),
+            degree,
+        ))
+    }
+}

--- a/circuit-prover/src/batch_stark_prover/tests.rs
+++ b/circuit-prover/src/batch_stark_prover/tests.rs
@@ -5,8 +5,8 @@ use p3_circuit::ops::poseidon1_perm::{
 };
 use p3_circuit::ops::poseidon2_perm::{GoldilocksD2Width8, Poseidon2PermCallBase};
 use p3_circuit::ops::{
-    KoalaBearD1Width16, Poseidon1Config, Poseidon2Config, generate_poseidon1_trace,
-    generate_poseidon2_trace, generate_recompose_trace,
+    KoalaBearD1Width16, NpoTypeId, Poseidon1Config, Poseidon2Config, generate_expose_claim_trace,
+    generate_poseidon1_trace, generate_poseidon2_trace, generate_recompose_trace,
 };
 use p3_field::PrimeCharacteristicRing;
 use p3_field::extension::{BinomialExtensionField, QuinticTrinomialExtensionField};
@@ -19,8 +19,9 @@ use super::*;
 use crate::ConstraintProfile;
 use crate::batch_stark_prover::{
     BABY_BEAR_MODULUS, KOALA_BEAR_MODULUS, Poseidon1Preprocessor, Poseidon2Preprocessor,
-    poseidon1_air_builders_d5, poseidon1_table_provers_d5, poseidon2_air_builders,
-    poseidon2_air_builders_d5, poseidon2_table_provers_d5, recompose_air_builders,
+    expose_claim_air_builders, expose_claim_preprocessor, poseidon1_air_builders_d5,
+    poseidon1_table_provers_d5, poseidon2_air_builders, poseidon2_air_builders_d5,
+    poseidon2_table_provers_d5, recompose_air_builders,
 };
 use crate::common::{NpoPreprocessor, get_airs_and_degrees_with_prep};
 use crate::config::{self, BabyBearConfig, GoldilocksConfig, KoalaBearConfig};
@@ -1320,4 +1321,77 @@ fn test_koalabear_quintic_trinomial_batch_stark_with_poseidon1_d1() {
     prover
         .verify_all_tables::<QuinticTrinomialExtensionField<KoalaBear>>(&proof)
         .unwrap();
+}
+
+/// `expose_as_public_output` surfaces chosen in-circuit witnesses as host-readable
+/// table public values, BOUND to the genuine witnesses via the `WitnessChecks` bus.
+///
+/// This exercises the general public-output channel standalone (no recursion): a
+/// base-field circuit computes some witnesses, marks three of them for exposure,
+/// and after proving + verifying, the host reads them back out of
+/// `proof.non_primitives[].public_values` — provably equal to the genuine values
+/// the prover computed, not free prover-chosen scalars.
+#[test]
+fn test_babybear_expose_as_public_output() {
+    let mut builder = CircuitBuilder::<BabyBear>::new();
+    builder.enable_expose_claim::<BabyBear>(generate_expose_claim_trace::<BabyBear, BabyBear>);
+
+    // Ordinary circuit: a, b are inputs; sum and prod are internal computed witnesses.
+    let a = builder.public_input();
+    let b = builder.public_input();
+    let sum = builder.add(a, b);
+    let prod = builder.mul(a, b);
+
+    // Surface a mix of an input and two internal witnesses as bound public outputs.
+    builder.expose_as_public_output(&[a, sum, prod]);
+
+    let circuit = builder.build().unwrap();
+    let cfg = config::baby_bear();
+
+    let npo_prep: Vec<Box<dyn NpoPreprocessor<BabyBear>>> =
+        vec![expose_claim_preprocessor::<BabyBear>()];
+    let air_builders = expose_claim_air_builders::<BabyBearConfig, 1>();
+    let (airs_degrees, primitive_columns, non_primitive_columns) =
+        get_airs_and_degrees_with_prep::<BabyBearConfig, _, 1>(
+            &circuit,
+            &TablePacking::default(),
+            &npo_prep,
+            &air_builders,
+            ConstraintProfile::Standard,
+        )
+        .unwrap();
+    let (airs, log_degrees): (Vec<_>, Vec<usize>) = airs_degrees.into_iter().unzip();
+
+    let mut runner = circuit.runner();
+    let a_val = BabyBear::from_u64(7);
+    let b_val = BabyBear::from_u64(5);
+    runner.set_public_inputs(&[a_val, b_val]).unwrap();
+    let traces = runner.run().unwrap();
+
+    let prover_data = ProverData::from_airs_and_degrees(&cfg, &airs, &log_degrees);
+    let circuit_prover_data =
+        CircuitProverData::new(prover_data, primitive_columns, non_primitive_columns);
+
+    let mut prover = BatchStarkProver::new(cfg);
+    prover.register_expose_claim_table::<1>();
+
+    let proof = prover
+        .prove_all_tables(&traces, &circuit_prover_data)
+        .unwrap();
+
+    // The verifier accepts the proof (the bus stays balanced: the reader's `-1`
+    // multiplicity is matched by the creating table's send).
+    prover.verify_all_tables::<BabyBear>(&proof).unwrap();
+
+    // The host reads the exposed witnesses back out of the proof, in order.
+    let entry = proof
+        .non_primitives
+        .iter()
+        .find(|e| e.op_type == NpoTypeId::expose_claim())
+        .expect("expose_claim table present in proof");
+    assert_eq!(
+        entry.public_values,
+        vec![a_val, a_val + b_val, a_val * b_val],
+        "exposed public values must equal the genuine in-circuit witnesses"
+    );
 }

--- a/circuit/src/builder/circuit_builder.rs
+++ b/circuit/src/builder/circuit_builder.rs
@@ -344,6 +344,49 @@ where
         self.recompose_npo_enabled = true;
     }
 
+    /// Enable the expose-claim NPO table.
+    ///
+    /// The expose-claim table reads existing witnesses off the `WitnessChecks`
+    /// bus (reader multiplicity `-1`) and surfaces their values as host-readable
+    /// `non_primitives[].public_values`, BOUND in-circuit to those genuine
+    /// witnesses. Use [`Self::expose_as_public_output`] to mark targets for
+    /// exposure after enabling.
+    pub fn enable_expose_claim<BF>(&mut self, trace_generator: TraceGeneratorFn<F>)
+    where
+        BF: PrimeField64,
+        F: ExtensionField<BF>,
+    {
+        let plugin = crate::ops::expose_claim::ExposeClaimCircuitPlugin::new(trace_generator);
+        self.register_npo(plugin);
+    }
+
+    /// Expose a set of targets as table public values, bound in-circuit to the
+    /// underlying witnesses via the `WitnessChecks` bus.
+    ///
+    /// All targets are exposed in ONE expose-claim table whose `public_values`
+    /// carry coeff-0 of each target in order. The FULL D-coeff ext tuple of each
+    /// target is read on the `WitnessChecks` bus and bus-bound to the genuine
+    /// witness; only coeff-0 is surfaced as the host-readable public value. The
+    /// higher coefficients are NOT constrained to zero (a witness may pack
+    /// genuinely-nonzero base lanes into one ext element, e.g. a Poseidon2 output
+    /// limb) — their soundness comes from the bus binding, not a local zero check.
+    ///
+    /// [`Self::enable_expose_claim`] must have been called first.
+    pub fn expose_as_public_output(&mut self, targets: &[ExprId]) {
+        if targets.is_empty() {
+            return;
+        }
+        self.push_scope("expose_as_public_output");
+        let _ = self.push_non_primitive_op_with_outputs(
+            NpoTypeId::expose_claim(),
+            vec![targets.to_vec()],
+            vec![],
+            Some(NonPrimitiveOpParams::ExposeClaim),
+            "expose_claim",
+        );
+        self.pop_scope();
+    }
+
     /// No-op recompose enablement: leaves `recompose_base_coeffs_to_ext` using
     /// the ALU fallback. Has the same signature as `enable_recompose` so it
     /// can be selected via a macro `$ident` parameter.

--- a/circuit/src/builder/npo.rs
+++ b/circuit/src/builder/npo.rs
@@ -28,6 +28,7 @@ pub enum NonPrimitiveOpParams<F> {
         executor: Box<dyn HintExecutor<F>>,
     },
     Recompose,
+    ExposeClaim,
 }
 
 impl<F> NonPrimitiveOpParams<F> {
@@ -88,6 +89,7 @@ impl<F: Field> Clone for NonPrimitiveOpParams<F> {
                 executor: executor.boxed(),
             },
             Self::Recompose => Self::Recompose,
+            Self::ExposeClaim => Self::ExposeClaim,
         }
     }
 }

--- a/circuit/src/ops/expose_claim.rs
+++ b/circuit/src/ops/expose_claim.rs
@@ -1,0 +1,282 @@
+//! ExposeClaim non-primitive operation: reads N existing witness values off the
+//! `WitnessChecks` bus and surfaces them as host-readable table public values.
+//!
+//! Unlike recompose/poseidon2 (which CREATE outputs on the bus), this op is a
+//! pure READER: it allocates no new witnesses. Each input witness is received
+//! off the bus with reader multiplicity `-1` (incrementing that witness's
+//! ext-read count, so the bus stays balanced against the writer that sent it),
+//! placed into a main column, and bound to the table's public value for that
+//! lane by the AIR. The result is a non-primitive table whose `public_values`
+//! carry exactly those N witness values, provably equal to the genuine
+//! in-circuit witnesses.
+
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::any::Any;
+use core::fmt::Debug;
+
+use p3_field::{ExtensionField, Field, PrimeField64};
+
+use crate::CircuitError;
+use crate::builder::{CircuitBuilderError, NpoCircuitPlugin, NpoLoweringContext};
+use crate::ops::{ExecutionContext, NonPrimitiveExecutor, NpoTypeId, Op, PreprocessedWriter};
+use crate::tables::{NonPrimitiveTrace, TraceGeneratorFn};
+use crate::types::{ExprId, WitnessId};
+
+/// Config payload stored in `NpoConfig` for the expose-claim table.
+#[derive(Debug, Clone)]
+pub(crate) struct ExposeClaimConfig;
+
+/// Per-row data captured during execution: which witness was read and its value.
+///
+/// `value` is the host-exposed scalar (coeff-0 of the read cell). `read_coeffs`
+/// holds ALL `D` base-field coefficients of the read witness — the table's main
+/// trace must reproduce the FULL witness value so the `WitnessChecks` receive
+/// tuple `[idx, c_0, ..., c_{D-1}]` exactly matches the tuple the witness's
+/// CREATOR sent (e.g. a W24 Poseidon2 output limb, whose higher coefficients are
+/// genuinely nonzero). Binding only coeff-0 and zeroing the rest would read a
+/// DIFFERENT tuple than the creator sent, unbalancing the global lookup bus.
+///
+/// On the execution-state rows `F` is the circuit extension field and `read_coeffs`
+/// is left empty (the trace generator derives it); on the base-field trace rows it
+/// is populated with the `D` coefficients.
+#[derive(Debug, Clone)]
+pub struct ExposeClaimCircuitRow<F> {
+    pub witness_id: WitnessId,
+    pub value: F,
+    pub read_coeffs: alloc::vec::Vec<F>,
+}
+
+/// Execution state collecting the exposed claim rows (in lane order).
+#[derive(Debug, Default)]
+pub struct ExposeClaimExecutionState<F> {
+    pub rows: Vec<ExposeClaimCircuitRow<F>>,
+}
+
+/// Executor for the expose-claim op. Reads the input witnesses and records them;
+/// writes no new witnesses.
+#[derive(Debug, Clone)]
+pub struct ExposeClaimExecutor {
+    op_type: NpoTypeId,
+}
+
+impl ExposeClaimExecutor {
+    pub fn new(op_type: NpoTypeId) -> Self {
+        Self { op_type }
+    }
+}
+
+impl<F: Field + Send + Sync + 'static> NonPrimitiveExecutor<F> for ExposeClaimExecutor {
+    fn execute(
+        &self,
+        inputs: &[Vec<WitnessId>],
+        outputs: &[Vec<WitnessId>],
+        ctx: &mut ExecutionContext<'_, F>,
+    ) -> Result<(), CircuitError> {
+        if inputs.len() != 1 {
+            return Err(CircuitError::NonPrimitiveOpLayoutMismatch {
+                op: self.op_type.clone(),
+                expected: "1 input group".to_string(),
+                got: inputs.len(),
+            });
+        }
+        if !outputs.is_empty() && !outputs.iter().all(Vec::is_empty) {
+            return Err(CircuitError::NonPrimitiveOpLayoutMismatch {
+                op: self.op_type.clone(),
+                expected: "no outputs (reader-only op)".to_string(),
+                got: outputs.len(),
+            });
+        }
+
+        let mut rows = Vec::with_capacity(inputs[0].len());
+        for &wid in &inputs[0] {
+            let value = ctx.get_witness(wid)?;
+            rows.push(ExposeClaimCircuitRow {
+                witness_id: wid,
+                value,
+                read_coeffs: alloc::vec::Vec::new(),
+            });
+        }
+
+        let state = ctx.get_op_state_mut::<ExposeClaimExecutionState<F>>(&self.op_type);
+        state.rows.extend(rows);
+
+        Ok(())
+    }
+
+    fn op_type(&self) -> &NpoTypeId {
+        &self.op_type
+    }
+
+    fn preprocess(
+        &self,
+        inputs: &[Vec<WitnessId>],
+        _outputs: &[Vec<WitnessId>],
+        preprocessed: &mut dyn PreprocessedWriter<F>,
+    ) -> Result<(), CircuitError> {
+        // Per-lane preprocessed layout (EF): [witness_idx, mult_placeholder].
+        // The preprocessor overwrites the placeholder with the reader
+        // multiplicity (-1). We also increment the witness's ext-read count so
+        // the PublicAir send that created it carries one more copy — keeping the
+        // WitnessChecks bus balanced.
+        for &wid in &inputs[0] {
+            preprocessed.register_non_primitive_output_index(&self.op_type, &[wid]);
+            preprocessed.register_non_primitive_preprocessed_no_read(&self.op_type, &[F::ONE]);
+            preprocessed.increment_ext_reads(&[wid]);
+        }
+        Ok(())
+    }
+
+    fn num_exposed_outputs(&self) -> Option<usize> {
+        // Reader-only: creates no outputs on the bus.
+        Some(0)
+    }
+
+    fn boxed(&self) -> Box<dyn NonPrimitiveExecutor<F>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Circuit-layer plugin for the expose-claim op.
+pub(crate) struct ExposeClaimCircuitPlugin<F: Field> {
+    trace_gen: TraceGeneratorFn<F>,
+}
+
+impl<F: Field> ExposeClaimCircuitPlugin<F> {
+    pub fn new(trace_gen: TraceGeneratorFn<F>) -> Self {
+        Self { trace_gen }
+    }
+}
+
+impl<F: Field> Debug for ExposeClaimCircuitPlugin<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExposeClaimCircuitPlugin").finish()
+    }
+}
+
+impl<F> NpoCircuitPlugin<F> for ExposeClaimCircuitPlugin<F>
+where
+    F: Field,
+{
+    fn type_id(&self) -> NpoTypeId {
+        NpoTypeId::expose_claim()
+    }
+
+    fn lower(
+        &self,
+        data: &crate::builder::NonPrimitiveOperationData<F>,
+        _output_exprs: &[(u32, ExprId)],
+        ctx: &mut NpoLoweringContext<'_, F>,
+    ) -> Result<Op<F>, CircuitBuilderError> {
+        if data.input_exprs.len() != 1 {
+            return Err(CircuitBuilderError::NonPrimitiveOpArity {
+                op: "ExposeClaim",
+                expected: "1 input group".to_string(),
+                got: data.input_exprs.len(),
+            });
+        }
+
+        let input_wids: Vec<WitnessId> = data.input_exprs[0]
+            .iter()
+            .enumerate()
+            .map(|(i, &expr)| ctx.resolve_witness_id(expr, &format!("ExposeClaim input {i}")))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Op::NonPrimitiveOpWithExecutor {
+            inputs: vec![input_wids],
+            outputs: vec![],
+            executor: Box::new(ExposeClaimExecutor::new(NpoTypeId::expose_claim())),
+            op_id: data.op_id,
+        })
+    }
+
+    fn trace_generator(&self) -> TraceGeneratorFn<F> {
+        self.trace_gen
+    }
+
+    fn config(&self) -> crate::ops::NpoConfig {
+        crate::ops::NpoConfig::new(ExposeClaimConfig)
+    }
+}
+
+// SAFETY: the only field is a bare `fn` pointer (`TraceGeneratorFn<F>`), which
+// is always `Send + Sync`. No `F` value is stored.
+unsafe impl<F: Field> Send for ExposeClaimCircuitPlugin<F> {}
+unsafe impl<F: Field> Sync for ExposeClaimCircuitPlugin<F> {}
+
+/// Trace for the expose-claim op.
+#[derive(Debug, Clone)]
+pub struct ExposeClaimTrace<F> {
+    pub operations: Vec<ExposeClaimCircuitRow<F>>,
+}
+
+impl<F> ExposeClaimTrace<F> {
+    pub const fn total_rows(&self) -> usize {
+        self.operations.len()
+    }
+}
+
+impl<TraceF: Clone + Send + Sync + 'static, CF> NonPrimitiveTrace<CF> for ExposeClaimTrace<TraceF> {
+    fn op_type(&self) -> NpoTypeId {
+        NpoTypeId::expose_claim()
+    }
+
+    fn rows(&self) -> usize {
+        self.total_rows()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn boxed_clone(&self) -> Box<dyn NonPrimitiveTrace<CF>> {
+        Box::new(self.clone())
+    }
+}
+
+/// Generate the expose-claim trace from execution state.
+///
+/// Each recorded value is an EF element `(c, 0, ..., 0)`; we extract `c` (the
+/// 0th basis coefficient) as a base-field value, then re-embed as EF.
+pub fn generate_expose_claim_trace<BF, EF>(
+    op_states: &crate::ops::OpStateMap,
+) -> Result<Option<Box<dyn NonPrimitiveTrace<EF>>>, CircuitError>
+where
+    BF: PrimeField64,
+    EF: Field + ExtensionField<BF>,
+{
+    let op_type = NpoTypeId::expose_claim();
+    let Some(state) = op_states
+        .get(&op_type)
+        .and_then(|s| s.downcast_ref::<ExposeClaimExecutionState<EF>>())
+    else {
+        return Ok(None);
+    };
+
+    if state.rows.is_empty() {
+        return Ok(None);
+    }
+
+    let operations: Vec<ExposeClaimCircuitRow<BF>> = state
+        .rows
+        .iter()
+        .map(|row| {
+            // Capture ALL `D` base-field coefficients of the read witness. The host
+            // value exposed is coeff-0, but the table's `WitnessChecks` receive must
+            // carry the FULL witness tuple so it matches the tuple the witness's
+            // creator sent (a base-field witness has zero higher coeffs; a Poseidon2
+            // output limb carries 4 genuinely-nonzero base lanes packed as one ext
+            // element). See `ExposeClaimCircuitRow` for why.
+            let coeffs = row.value.as_basis_coefficients_slice();
+            ExposeClaimCircuitRow {
+                witness_id: row.witness_id,
+                value: coeffs[0],
+                read_coeffs: coeffs.to_vec(),
+            }
+        })
+        .collect();
+
+    Ok(Some(Box::new(ExposeClaimTrace { operations })))
+}

--- a/circuit/src/ops/mod.rs
+++ b/circuit/src/ops/mod.rs
@@ -3,6 +3,7 @@ mod executor;
 mod npo;
 mod op;
 
+pub mod expose_claim;
 pub mod hash;
 pub mod mmcs;
 pub mod perm;
@@ -44,6 +45,7 @@ pub use poseidon2_perm::{
     Poseidon2Trace,
     generate_poseidon2_trace,
 };
+pub use expose_claim::{ExposeClaimCircuitRow, ExposeClaimTrace, generate_expose_claim_trace};
 pub use recompose::{
     RecomposeCircuitRow, RecomposeTrace, RecomposeTraceKind, generate_recompose_coeff_trace,
     generate_recompose_trace,

--- a/circuit/src/ops/npo.rs
+++ b/circuit/src/ops/npo.rs
@@ -48,6 +48,11 @@ impl NpoTypeId {
         Self::new("recompose")
     }
 
+    /// Convenience: ExposeClaim (read witnesses → table public values) operation type ID.
+    pub fn expose_claim() -> Self {
+        Self::new("expose_claim")
+    }
+
     /// Recompose table variant that registers per-coefficient WitnessChecks receives.
     ///
     /// Used when a D=1 Poseidon2 (or similar) must read individual BF coefficients that came


### PR DESCRIPTION
## What this adds

An opt-in non-primitive table, `expose_claim`, plus a builder method
`CircuitBuilder::expose_as_public_output(targets: &[ExprId])`, that surfaces
chosen in-circuit witnesses as **host-readable table public values, bound to the
genuine witnesses** via the `WitnessChecks` bus.

The table is a pure bus reader. For each chosen witness it receives the full
`[witness_idx, v_0, .., v_{D-1}]` tuple off the `WitnessChecks` bus with reader
multiplicity `-1` (so the bus stays balanced against the table that *created*
that witness), and constrains the table's public value for that lane to equal the
value it read. The host then reads `proof.non_primitives[].public_values` and is
guaranteed they are the genuine verified witnesses — not free prover-chosen
scalars.

## Why it's a general capability

As far as I can tell, upstream has no mechanism to bind an arbitrary in-circuit
witness to a host-readable *public output* of a recursive proof: `public_values`
/ `table_public_inputs` flow inward (values the AIR is checked against), and the
non-primitive tables (`poseidon2`, `recompose`, ...) all declare an empty
`public_values` vector.

A recursive/IVC light client that wants to read claims *out* of an aggregate
proof — a chain head, a Merkle root, a step counter, a running hash — needs
exactly this: an output channel whose values are provably the genuine in-circuit
witnesses. This is the abstracted primitive (the builder API + the AIR/op); the
specific orchestration we layer on top of it stays in our fork.

## On circuit weight (re: the discussion on #452)

This is **purely additive and opt-in**: the table only exists when a circuit
calls `enable_expose_claim` + `expose_as_public_output`. It adds **zero columns
and zero constraints** to any circuit that does not use it, and its own footprint
scales only with the number of values you choose to expose. It does not touch any
existing table. So it should not make anyone's circuit heavier — it is a new
capability you opt into, not a change to the default path. (One incidental fix:
`CircuitTableAir::num_public_values` now forwards to the dynamic AIR instead of
returning the default `0`; this is a no-op for every existing table, since they
declare no public values.)

## How it's tested

`batch_stark_prover::tests::test_babybear_expose_as_public_output`: a base-field
circuit exposes an input plus two internal computed witnesses (`a + b`, `a * b`),
and after `prove_all_tables` + `verify_all_tables` the host reads the three values
back out of the proof, asserted equal to the genuine in-circuit values. The full
`p3-circuit` (323) and `p3-circuit-prover` (46) lib suites pass off `main`.

## Caveat — please review carefully

This was developed with AI assistance while building an IVC layer on our fork. It
passes our suite but has **not been independently audited**, and it touches
soundness-relevant accounting (witness-slot reads, `WitnessChecks` bus
multiplicities, the public-value binding constraint). Please review with that in
mind. **Entirely happy for you to close this if it isn't a direction you want —
no hard feelings**; we can carry it on our fork either way.

This is a companion to #452 and part of the IVC-enablement work we built on our
fork. There is one further general piece we could offer as a follow-up if this is
useful: an in-circuit **VK-identity pin** (`pin_preprocessed_commit`) that binds a
child proof's preprocessed-commitment cap to expected constants, so a fold rejects
a proof of a *different* circuit — the stable anchor an IVC fixed-point needs. I
left it out here to keep this PR focused on one capability.
