### PR TITLE
fix: forward num_public_values in CircuitTableAir BaseAir impl

### DIFF
--- a/circuit-prover/src/batch_stark_prover.rs
+++ b/circuit-prover/src/batch_stark_prover.rs
@@ -882,6 +882,7 @@ where
             }
         }
     }
+}
 
 macro_rules! impl_circuit_table_air_for_builder {
     ($builder_ty:ty) => {

--- a/circuit-prover/src/batch_stark_prover.rs
+++ b/circuit-prover/src/batch_stark_prover.rs
@@ -874,14 +874,14 @@ where
 
     fn num_public_values(&self) -> usize {
         match self {
-            Self::Const(a) => a.num_public_values(),
-            Self::Public(a) => a.num_public_values(),
-            Self::Alu(a) => a.num_public_values(),
-            Self::Dynamic(a) =>
-                <dyn CloneableBatchAir<SC> as BaseAir<Val<SC>>>::num_public_values(a.air()),
+            Self::Const(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Public(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Alu(a) => BaseAir::<Val<SC>>::num_public_values(a),
+            Self::Dynamic(a) => {
+                <dyn CloneableBatchAir<SC> as BaseAir<Val<SC>>>::num_public_values(a.air())
+            }
         }
     }
-}
 
 macro_rules! impl_circuit_table_air_for_builder {
     ($builder_ty:ty) => {

--- a/circuit-prover/src/batch_stark_prover.rs
+++ b/circuit-prover/src/batch_stark_prover.rs
@@ -853,6 +853,16 @@ where
             }
         }
     }
+
+    fn num_public_values(&self) -> usize {
+        match self {
+            Self::Const(a) => a.num_public_values(),
+            Self::Public(a) => a.num_public_values(),
+            Self::Alu(a) => a.num_public_values(),
+            Self::Dynamic(a) =>
+                <dyn CloneableBatchAir<SC> as BaseAir<Val<SC>>>::num_public_values(a.air()),
+        }
+    }
 }
 
 macro_rules! impl_circuit_table_air_for_builder {


### PR DESCRIPTION
### What this does
Adds the missing `num_public_values` forwarding method to the `BaseAir` implementation for `CircuitTableAir`.

### Why it's needed
Currently, `CircuitTableAir` explicitly forwards `width`, `preprocessed_width`, and `preprocessed_trace`, but omits `num_public_values`. 

Because `BaseAir` provides a default implementation of `fn num_public_values(&self) -> usize { 0 }`, the compiler doesn't catch this omission. 

If a user defines a custom Non-Primitive Operation (NPO) table using the plugin system that *does* expose public values, `from_airs_and_degrees` incorrectly reads `0` for that table. This results in the symbolic builder receiving an empty public values slice, which causes a panic (`index out of bounds`) when the custom AIR attempts to evaluate constraints against its public values. 

This one-line match arm ensures custom dynamic AIRs correctly report their public value count to the prover.